### PR TITLE
ci: 最新のclaude-code-reviewのテンプレートを使用しopusモデルを指定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   claude-review:
     # Optional: Filter by PR author
+    if: github.actor != 'dependabot[bot]' # Dependabotの場合は認証が通らないのでスキップ。
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
@@ -24,12 +25,13 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 50
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -51,8 +53,7 @@ jobs:
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
+          # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
+            --model opus
             --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
-
-          use_sticky_comment: true


### PR DESCRIPTION
- github.actorがdependabotの場合はジョブをスキップする条件を追加
- claude-code-actionのモデルにopusを明示的に指定
- actions/checkoutをv6にアップデートしfetch-depthを50に変更
- ドキュメントURLを最新に更新
