### PR TITLE
fix(cabal): tested-withをGHC 9.10.3に修正

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -9,7 +9,7 @@ author: ncaq
 maintainer: ncaq@ncaq.net
 category: Control
 build-type: Simple
-tested-with: ghc ==9.10.2
+tested-with: ghc ==9.10.3
 
 common basic
   ghc-options:


### PR DESCRIPTION
ここも修正漏れになっていました。
クロスでビルドしていれば問題ないのですが。
まだその準備は整っていません。
