### PR TITLE
docs(nix): meta.descriptionに説明文を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,7 @@
         apps = flake.apps // {
           generate-hlint = {
             type = "app";
+            meta.description = "Generate .hlint.yaml from Dhall source";
             program = pkgs.lib.getExe (
               pkgs.writeShellApplication {
                 name = "generate-hlint";


### PR DESCRIPTION
- `generate-hlint`パッケージに説明文を追加
- Dhallソースから`.hlint.yaml`を生成する旨を明記
