### PR TITLE
feat(cabal): `.hlint.yaml`を`data-files`に追加

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -9,6 +9,7 @@ author: ncaq
 maintainer: ncaq@ncaq.net
 category: Control
 build-type: Simple
+data-files: .hlint.yaml
 tested-with:
   ghc ==9.10.2
   ghc ==9.10.3


### PR DESCRIPTION
このプロジェクトにおいては`.hlint.yaml`は単なる設定ファイルではなく、
ユーザに配布するファイルなため。
