### PR TITLE
build(deps): `directory`への直接依存を削除

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -36,7 +36,6 @@ common basic
     containers ^>=0.7,
     convertible ^>=1.1.1.1,
     deepseq ^>=1.5.0.0,
-    directory ^>=1.3.9.0,
     exceptions ^>=0.10.9,
     filepath ^>=1.5.4.0,
     hashable ^>=1.5.0.0,

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -37,7 +37,6 @@ import Data.Void as Export
 import Data.Word as Export
 import Debug.Pretty.Simple as Export
 import GHC.Generics as Export hiding (from, to)
-import System.Directory as Export
 import System.FilePath as Export hiding ((<.>))
 import System.Process.Typed as Export
 import Text.Pretty.Simple as Export


### PR DESCRIPTION
`UnliftIO.Directory`があるから必要ないことに気が付きました。
`exceptions`の方は`MonadThrow`などをunliftioはexportしていないようなので、
引き続き依存しています。
