### PR TITLE
ci: GitHub Actionsでcabalバージョン変更時に自動タグ付けを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
             echo "Failed to extract version from himari.cabal"
             exit 1
           fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+(\.[0-9]+){1,3}$'; then
+            echo "Invalid PVP version format: $VERSION"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Check if tag exists
         id: check_tag


### PR DESCRIPTION
- masterブランチでhimari.cabalのバージョン変更時に自動でタグを作成
- 既存タグがない場合のみ新しいタグをpush
- GitHub Actionsの権限設定とcheckoutのfetch-depthを調整
