### PR TITLE
docs: extra-doc-filesに追加するべきものを登録

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## [Unreleased]
+
+### Added
+
+- Himari.Prelude module as a custom Prelude
+- Himari.Logger module for logging utilities
+- Himari.Env module for environment handling
+- Himari.Env.Simple module for simple environment management
+- Bundled .hlint.yaml configuration as data-files

--- a/himari.cabal
+++ b/himari.cabal
@@ -10,6 +10,10 @@ maintainer: ncaq@ncaq.net
 category: Control
 build-type: Simple
 data-files: .hlint.yaml
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
 tested-with:
   ghc ==9.10.2
   ghc ==9.10.3


### PR DESCRIPTION
- CHANGELOG.mdを新規作成し、主要な追加機能を記載
- himari.cabalのextra-doc-filesにCHANGELOG.mdとREADME.mdを追加
