### PR TITLE
ci: releaseワークフローのトリガーを一時的に無効化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: release
 
+on:
+  workflow_dispatch:
 # まだリリースできる段階にはないので一旦無効化しておきます。
 # リリースできる段階になったらコメントアウトを外してください。
-# on:
 #   push:
 #     branches:
 #       - master


### PR DESCRIPTION
- リリース可能な段階になるまでonセクションをコメントアウト
- コメントを追加して再有効化のタイミングを明示
