### PR TITLE
build(treefmt): actionlintの有効化をflake.nixに追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,10 +127,10 @@
         };
         flake = pkgs.project.flake { };
         treefmtEval = treefmt-nix.lib.evalModule pkgs (_: {
-          # actionlintはセルフホストランナーの設定ファイルを正常に読み込まなかった。
           # yamlfmtはprettierと競合する。
           projectRootFile = "flake.nix";
           programs = {
+            actionlint.enable = true;
             cabal-gild.enable = true;
             deadnix.enable = true;
             dhall.enable = true;


### PR DESCRIPTION
よく考えてみたらコピー元がそうだっただけで、
このプロジェクトはセルフホストランナーを使っていなかったので、
無効化する必要はなかった。
