### PR TITLE
feat(hlint): 並行処理のhlintルールを更新し `.hlint.yaml` を再生成

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -288,10 +288,28 @@
       name: Data.ByteString.Unsafe.unsafeDrop
       within: []
 - functions:
-    - message: "Exceptions don't propagate to parent thread. Use async library."
+    - message: "Exceptions don't propagate to parent thread. Use async or withAsync from UnliftIO.Async instead."
       name: forkIO
       within: []
-    - message: Almost impossible to use correctly. Use async library.
+    - message: "Exceptions don't propagate to parent thread. Use asyncBound or withAsyncBound from UnliftIO.Async instead."
+      name: forkOS
+      within: []
+    - message: "Exceptions don't propagate to parent thread. Use asyncOn or withAsyncOn from UnliftIO.Async instead."
+      name: forkOn
+      within: []
+    - message: "Exceptions don't propagate to parent thread. Use asyncWithUnmask or withAsyncWithUnmask from UnliftIO.Async instead."
+      name: forkIOWithUnmask
+      within: []
+    - message: "Deprecated and exceptions don't propagate. Use asyncWithUnmask or withAsyncWithUnmask from UnliftIO.Async instead."
+      name: forkWithUnmask
+      within: []
+    - message: Use withAsync from UnliftIO.Async for automatic cancellation and exception handling.
+      name: forkFinally
+      within: []
+    - message: Prefer structured cancellation with cancel or withAsync from UnliftIO.Async.
+      name: killThread
+      within: []
+    - message: "Almost impossible to use correctly. Consider using typed-process or UnliftIO.Async."
       name: forkProcess
       within: []
 - functions:

--- a/hlint/rules/concurrency.dhall
+++ b/hlint/rules/concurrency.dhall
@@ -7,10 +7,28 @@ let rules
     = [ Builder.functions
           [ Builder.restrictFunction
               "forkIO"
-              "Exceptions don't propagate to parent thread. Use async library."
+              "Exceptions don't propagate to parent thread. Use async or withAsync from UnliftIO.Async instead."
+          , Builder.restrictFunction
+              "forkOS"
+              "Exceptions don't propagate to parent thread. Use asyncBound or withAsyncBound from UnliftIO.Async instead."
+          , Builder.restrictFunction
+              "forkOn"
+              "Exceptions don't propagate to parent thread. Use asyncOn or withAsyncOn from UnliftIO.Async instead."
+          , Builder.restrictFunction
+              "forkIOWithUnmask"
+              "Exceptions don't propagate to parent thread. Use asyncWithUnmask or withAsyncWithUnmask from UnliftIO.Async instead."
+          , Builder.restrictFunction
+              "forkWithUnmask"
+              "Deprecated and exceptions don't propagate. Use asyncWithUnmask or withAsyncWithUnmask from UnliftIO.Async instead."
+          , Builder.restrictFunction
+              "forkFinally"
+              "Use withAsync from UnliftIO.Async for automatic cancellation and exception handling."
+          , Builder.restrictFunction
+              "killThread"
+              "Prefer structured cancellation with cancel or withAsync from UnliftIO.Async."
           , Builder.restrictFunction
               "forkProcess"
-              "Almost impossible to use correctly. Use async library."
+              "Almost impossible to use correctly. Consider using typed-process or UnliftIO.Async."
           ]
       ]
 


### PR DESCRIPTION
- forkIO の警告を更新し UnliftIO.Async の async/withAsync を推奨
- forkOS を追加し asyncBound/withAsyncBound を推奨
- forkOn を追加し asyncOn/withAsyncOn を推奨
- forkIOWithUnmask と forkWithUnmask を追加し asyncWithUnmask 系を推奨
- forkFinally を追加し withAsync による自動キャンセルを推奨
- killThread を追加し cancel や withAsync による構造的取消を推奨
- forkProcess の警告を見直し typed-process か UnliftIO.Async を提案
