### PR TITLE
ci(release): Hackage公開用のビルド・ドキュメント生成・公開処理を追加

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read # リポジトリコンテンツの読み取り
-  actions: write # キャッシュアクションに必要
 
 jobs:
   nix-flake-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 #       - "himari.cabal"
 
 permissions:
-  actions: write # キャッシュアクションに必要かもしれない
   contents: write
 
 jobs:


### PR DESCRIPTION
close #49

- free-disk-spaceアクションを追加しディスク容量を確保
- NixとCachixのセットアップステップを追加
- cabal sdistによるソース配布物のビルドを追加
- cabal haddock --haddock-for-hackageでHackage用ドキュメント生成を追加
- haskell-actions/hackage-publishアクションでHackageへの公開を自動化
