### PR TITLE
docs: ドキュメントコメントのシンタックスエラーを減らす

### DIFF
--- a/src/Himari.hs
+++ b/src/Himari.hs
@@ -1,3 +1,4 @@
+-- | Custom Prelude library providing a comprehensive set of commonly used modules and utilities.
 module Himari (module Export) where
 
 import Himari.Char as Export

--- a/src/Himari/Char.hs
+++ b/src/Himari/Char.hs
@@ -8,14 +8,14 @@ module Himari.Char
 import Data.Char qualified as C
 import Himari.Prelude
 
--- | Safe version of 'digitToInt'.
+-- | Safe version of "Data.Char".'digitToInt'.
 --
 -- Converts a hexadecimal digit character to the corresponding 'Int' value.
 -- Accepts decimal digits (@\'0\'@-@\'9\'@), lowercase hex digits (@\'a\'@-@\'f\'@),
 -- and uppercase hex digits (@\'A\'@-@\'F\'@).
 --
 -- Returns 'Nothing' for characters outside the valid range,
--- instead of throwing an exception like 'digitToInt'.
+-- instead of throwing an exception like "Data.Char".'digitToInt'.
 --
 -- >>> digitToIntMay '0'
 -- Just 0
@@ -34,13 +34,13 @@ digitToIntMay c
   | C.isHexDigit c = Just (C.digitToInt c {- HLINT ignore "Avoid restricted function" -})
   | otherwise = Nothing
 
--- | Safe version of 'intToDigit'.
+-- | Safe version of "Data.Char".'intToDigit'.
 --
 -- Converts an 'Int' in the range 0..15 to the corresponding
--- single hexadecimal digit 'Char' (using lowercase 'a'-'f' for 10-15).
+-- single hexadecimal digit 'Char' (using lowercase @\'a\'@-@\'f\'@ for 10-15).
 --
 -- Returns 'Nothing' for values outside the valid range,
--- instead of throwing an exception like 'intToDigit'.
+-- instead of throwing an exception like "Data.Char".'intToDigit'.
 --
 -- >>> intToDigitMay 0
 -- Just '0'
@@ -57,14 +57,14 @@ intToDigitMay n
   | 0 <= n, n <= 15 = Just (C.intToDigit n {- HLINT ignore "Avoid restricted function" -})
   | otherwise = Nothing
 
--- | Safe version of 'chr'.
+-- | Safe version of "Data.Char".'chr'.
 --
 -- Converts an 'Int' to a Unicode 'Char'.
 -- Valid code points are 0 to 0x10FFFF, excluding the surrogate range
 -- 0xD800 to 0xDFFF.
 --
 -- Returns 'Nothing' for invalid code points,
--- instead of throwing an exception like 'chr'.
+-- instead of throwing an exception like "Data.Char".'chr'.
 --
 -- >>> chrMay 65
 -- Just 'A'

--- a/src/Himari/Env.hs
+++ b/src/Himari/Env.hs
@@ -11,7 +11,7 @@ module Himari.Env
 import Himari.Prelude
 
 -- | The Reader + IO monad.
--- It is nearly equal to `RIO`.
+-- It is nearly equal to @RIO@ from the rio package.
 newtype Himari env a = Himari
   { unHimari :: ReaderT env IO a
   }

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 
+-- | Logger utilities for Himari.
 module Himari.Logger
   ( HasLogAction (..)
   , LogAction

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -1,4 +1,4 @@
--- | Alternative to `Prelude`.
+-- | Alternative to "Prelude".
 module Himari.Prelude
   ( module Export
   -- Type only re-exports.


### PR DESCRIPTION
- 各モジュールのドキュメントコメントを追加・修正
- 関数説明内の参照を "Data.Char".'関数名' などの形式に統一
- Himari.Env で RIO への参照を明確化
- Himari.Prelude の説明を "Prelude" 参照に修正
