### PR TITLE
feat(hlint): yamlパッケージ向けのHLintルールを追加

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -3548,3 +3548,14 @@
     - message: "Unsafe: passes raw pointer to IO action without safety guarantees."
       name: Data.Vector.Storable.Mutable.unsafeWith
       within: []
+- functions:
+    - message: "Discards error info. Use decodeEither' or decodeThrow instead."
+      name: Data.Yaml.decode
+      within: []
+    - message: Discards error info. Use decodeFileEither or decodeFileThrow instead.
+      name: Data.Yaml.decodeFile
+      within: []
+- functions:
+    - message: "Deprecated. Use decodeEither' instead for ParseException details."
+      name: Data.Yaml.decodeEither
+      within: []

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -28,5 +28,6 @@ let rules
       # ./rules/unordered-containers.dhall
       # ./rules/unsafe.dhall
       # ./rules/vector.dhall
+      # ./rules/yaml.dhall
 
 in  rules

--- a/hlint/rules/yaml.dhall
+++ b/hlint/rules/yaml.dhall
@@ -1,0 +1,25 @@
+let Types = ../Types.dhall
+
+let Builder = ../Builder.dhall
+
+let rules
+    : List Types.Rule
+    = [ Builder.functions
+          [ Builder.restrictInModule
+              "Data.Yaml"
+              "decode"
+              "Discards error info. Use decodeEither' or decodeThrow instead."
+          , Builder.restrictInModule
+              "Data.Yaml"
+              "decodeFile"
+              "Discards error info. Use decodeFileEither or decodeFileThrow instead."
+          ]
+      , Builder.functions
+          [ Builder.restrictInModule
+              "Data.Yaml"
+              "decodeEither"
+              "Deprecated. Use decodeEither' instead for ParseException details."
+          ]
+      ]
+
+in  rules


### PR DESCRIPTION
- Data.Yaml.decode および decodeFile の使用を制限
- Data.Yaml.decodeEither の使用を制限
- エラー情報を破棄しない代替関数の使用を推奨
