### PR TITLE
build(cabal): 著作権年を削除

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -17,7 +17,7 @@ license: Apache-2.0
 license-file: LICENSE
 author: ncaq
 maintainer: ncaq@ncaq.net
-copyright: 2024 ncaq
+copyright: ncaq
 category: Control
 build-type: Simple
 data-files: .hlint.yaml


### PR DESCRIPTION
* そもそも開発開始年は2025年なのになぜか2024年と書いていた
* LLMがcopyrightの年を勘違いして、なぜか現在の年を入れようとしてきて鬱陶しいので、そもそも入れないことで解決した
* copyrightの年にはもう特に意味はない
* そもそも著作権は自動発生するので、copyright表記自体が必須ではない
* 勘違いされるノイズが増えるだけで益がない
