### PR TITLE
ci: changelog-lintの依存とCIチェックをflakeに追加

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,22 @@
         "type": "github"
       }
     },
+    "changelog-lint-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667633745,
+        "narHash": "sha256-ZVLuE0SbNY1LZ773GeVs3em/G2vCNRXiV41VYNOtcGA=",
+        "ref": "refs/heads/master",
+        "rev": "e9310dee1b58d2bd19223034d48a654849bc9d96",
+        "revCount": 49,
+        "type": "git",
+        "url": "https://codeberg.org/chavacava/changelog-lint.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/chavacava/changelog-lint.git"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -605,6 +621,7 @@
     },
     "root": {
       "inputs": {
+        "changelog-lint-src": "changelog-lint-src",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,10 @@
       };
     };
     haskellNix.url = "github:input-output-hk/haskell.nix";
+    changelog-lint-src = {
+      url = "git+https://codeberg.org/chavacava/changelog-lint.git";
+      flake = false;
+    };
   };
 
   outputs =
@@ -18,6 +22,7 @@
       flake-utils,
       treefmt-nix,
       haskellNix,
+      changelog-lint-src,
     }:
     # 現状はLinuxのみを想定。
     let
@@ -101,6 +106,7 @@
                 dhall-docs
                 dhall-lsp-server
                 dhall-yaml
+                final.changelog-lint
                 fourmolu
                 hlint
                 nil
@@ -115,6 +121,12 @@
                 '')
               ];
             };
+          };
+          changelog-lint = final.buildGoModule {
+            pname = "changelog-lint";
+            version = "0.3.0";
+            src = changelog-lint-src;
+            vendorHash = "sha256-b0cTP7aIh26/E9BvG6aGnpktmFmL49Nb8t4AhWvZzP8=";
           };
         })
       ];
@@ -207,6 +219,10 @@
           // flake.checks
           // {
             formatting = treefmtEval.config.build.check self;
+            changelog-lint = pkgs.runCommand "changelog-lint" { } ''
+              ${pkgs.changelog-lint}/bin/changelog-lint ${self}/CHANGELOG.md
+              touch $out
+            '';
           };
         formatter = treefmtEval.config.build.wrapper;
       }


### PR DESCRIPTION
- changelog-lint-srcをinputsに追加しGoモジュールとしてビルド
- flake.checksにCHANGELOG.mdのlint用ジョブを追加
- changelog-lintバイナリを開発環境パッケージに含める
