### PR TITLE
ci: changelog-lint用のPVPバージョン設定ファイルを追加

### DIFF
--- a/.changelog-lint.toml
+++ b/.changelog-lint.toml
@@ -1,0 +1,6 @@
+# changelog-lint configuration for Haskell PVP versioning
+# https://pvp.haskell.org/
+
+[parser.patterns]
+# PVP format: A.B.C.D (4 numbers) instead of semver (3 numbers)
+version = '^## \[?(\d+\.\d+\.\d+\.\d+|Unreleased)\]?( .*)*$'

--- a/flake.nix
+++ b/flake.nix
@@ -220,7 +220,7 @@
           // {
             formatting = treefmtEval.config.build.check self;
             changelog-lint = pkgs.runCommand "changelog-lint" { } ''
-              ${pkgs.changelog-lint}/bin/changelog-lint ${self}/CHANGELOG.md
+              ${pkgs.changelog-lint}/bin/changelog-lint -config ${self}/.changelog-lint.toml ${self}/CHANGELOG.md
               touch $out
             '';
           };


### PR DESCRIPTION
semverしか受け入れられなかったことに気がついた。

- .changelog-lint.tomlを新規追加しPVP形式のバージョン検証を設定
- flake.nixでchangelog-lint実行時に設定ファイルを参照するよう修正
