### PR TITLE
chore(release): v1.0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+## [1.0.3.1] - 2026-01-08
+
 ### Added
 
 - HLint language extension support in Dhall configuration

--- a/himari.cabal
+++ b/himari.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: himari
-version: 1.0.3.0
+version: 1.0.3.1
 synopsis: A standard library for Haskell as an alternative to rio
 description:
   A standard library for Haskell inspired by rio.


### PR DESCRIPTION
`.hlint.yaml`の更新だけなのでpatchバージョンが妥当だと思います。
