### PR TITLE
chore(release): v1.0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+## [1.0.4.0] - 2026-01-09
+
 ### Added
 
 - `UnliftIO.Concurrent` re-export in `Himari.Prelude` for lifted concurrent operations

--- a/himari.cabal
+++ b/himari.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: himari
-version: 1.0.3.2
+version: 1.0.4.0
 synopsis: A standard library for Haskell as an alternative to rio
 description:
   A standard library for Haskell inspired by rio.


### PR DESCRIPTION
一応re-exportするモジュールを増やしたので、
patchではなくminorなバージョンアップ。
