### PR TITLE
style(editorconfig): 最新の知見を反映

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,8 +16,8 @@ max_line_length = 120
 indent_style = space
 indent_size = 2
 
-# 標準インデントが4の言語とGitHubがMarkdownの順序付きリストのインデントを2だと適切にパースできないことに対応。
-[*.{cs,csx,java,kt,kts,md,php,py,pyi,rs}]
+# 標準インデントが4の言語。
+[*.{cs,csx,java,kt,kts,php,py,pyi,rs}]
 indent_size = 4
 
 # 標準インデントがタブの言語。
@@ -29,6 +29,13 @@ indent_style = tab
 # 注意: なるべく強制改行は使わず、意味で段落して、改行位置はクライアントのデバイスに任せるべきです。
 trim_trailing_whitespace = false
 # MarkdownはURLやコード例が長くなることが多いため行幅制限を緩めます。
+max_line_length = 200
+# MarkdownはCommonMark準拠パーサーでは箇条書きリストのネストは2スペースでも動作し、
+# 番号付きリストはマーカー幅に依存するため固定値での指定は不適切です。
+# よって`indent_size = 4`を指定するのも不適切なため指定せず親の値を継承します。
+
+[*.nix]
+# Nix言語を使った設定はコメントなどでURLやコード例が長くなることが多いため行幅制限を緩めます。
 max_line_length = 200
 
 [*.bat]


### PR DESCRIPTION
- Markdownのインデント設定を他言語と分離し、説明コメントを追加
- Markdownのindent_size指定を削除し、親設定を継承するよう変更
- Nixファイルのmax_line_lengthを200に設定
- インデント4の言語リストからmdを除外し説明を明確化
