### PR TITLE
build(deps-dev): sydtestの依存バージョン上限を緩和

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -143,7 +143,7 @@ test-suite himari-test
   build-depends:
     QuickCheck ^>=2.15.0.1,
     himari,
-    sydtest ^>=0.18.0.0,
+    sydtest >=0.18.0.0 && <0.24,
 
   build-tool-depends:
     hlint:hlint ^>=3.10


### PR DESCRIPTION
nixpkgsのsydtestが0.20.0.1に更新されたため、
`^>=0.18.0.0`(つまり`<0.19`)ではビルドできずbroken扱いになっていました。
0.18→0.23の破壊的変更を確認し、himariが使用するAPIに影響がないことを確認したため、
上限を`<0.24`に広げました。
