### PR TITLE
docs(changelog): `sydtest`依存バージョン上限の緩和をCHANGELOGに追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 - GHC 9.14.1 support
 
+### Changed
+
+- Relax `sydtest` dependency upper bound from `<0.19` to `<0.24` to support nixpkgs sydtest 0.20.0.1+
+
 ### Removed
 
 - Drop Intel Mac (x86_64-darwin) from Nix build targets due to Nix ending support for this platform


### PR DESCRIPTION
コミットe111152で`sydtest`の依存バージョン上限を`<0.19`から`<0.24`に緩和しましたが、
CHANGELOGへの記載が漏れていたため追記しました。
