### PR TITLE
ci: ビルド系のタイムアウトを明示的な最大値の360に設定します

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read # Read repository contents
       id-token: write # niks3 OIDC authentication
-    timeout-minutes: 120
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-2025
     permissions:
       contents: read # Read repository contents
-    timeout-minutes: 120
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
lockファイルの更新などでキャッシュが大幅に切れると、
特にMacランナーでビルドがタイムアウトが頻繁に発生します。
リトライも面倒なのでタイムアウトを最大の360分に設定します。
デフォルト値で既に360分ですが、
明示的に設定することでどれだけの余裕を持たせているかをわかりやすくします。
