### PR TITLE
build(deps-dev): programming-tasukeスキルを有効にする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,13 +4,14 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v6.2.0"
+        "ref": "v6.3.0"
       }
     }
   },
   "enabledPlugins": {
     "kyosei@konoka": true,
-    "nix-tasuke@konoka": true
+    "nix-tasuke@konoka": true,
+    "programming-tasuke@konoka": true
   },
   "enableAllProjectMcpServers": true,
   "permissions": {


### PR DESCRIPTION
konoka v6.3.0で追加されたprogramming-tasukeスキルを有効にします。