### PR TITLE
build(flake): `cabalProject'`のsrcを必要なファイルのみに絞る

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,28 @@
         )
         (final: prev: {
           project = final.haskell-nix.cabalProject' {
-            src = ./.;
+            # cabalビルドに必要なファイルのみをsrcに含める。
+            # 関係ないファイル(.editorconfig, .githubなど)の変更で内部derivationのhashが動き、
+            # キャッシュミスが発生するのを避ける。
+            src = final.lib.fileset.toSource {
+              root = ./.;
+              fileset = final.lib.fileset.unions [
+                # dir
+                ./src
+                ./test
+                # file
+                ./cabal.project
+                ./himari.cabal
+                # license-file
+                ./LICENSE
+                # data-files
+                ./.hlint.yaml
+                ./fourmolu.yaml
+                # extra-doc-files
+                ./CHANGELOG.md
+                ./README.md
+              ];
+            };
             compiler-nix-name = ghc-version;
             modules = [
               # `nix flake check`レベルではcabalの警告をエラーとして扱います。


### PR DESCRIPTION
`src = ./.;`のままだと`.editorconfig`や`.github`など、
Haskellビルドに無関係なファイルの変更でも`plan-nix` derivationの入力hashが動き、
下流の全コンポーネントの drv hashが変わってキャッシュミスが発生していました。

`lib.fileset.toSource`を使って`cabal build`に必要なものだけを列挙する形に変更します。
`cleanGit`ではgit管理ファイル全体が含まれてしまい、
README変更だけでも drv hashが動くため不十分でした。
`haskell.nix`の`cleanCabalComponent`は個別コンポーネントの build drvにのみ効き、
上流の`plan-nix`の入力にはsrc全体が渡るため、
これも単独では効果がありません。

allowlist方式で必要なものを明示する形にしたので、
新規にHaskellソースを追加してもfileset側の修正は不要ですが、
新しい設定ファイルやドキュメントを追加した時のみfileset更新が必要になります。
