### PR TITLE
feat(prelude): `Numeric`モジュールをエクスポートに追加

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -741,6 +741,22 @@
       name: Control.Monad.Identity
       within: []
 - functions:
+    - message: "Partial: throws on base <= 1 or negative input. Ensure base > 1 and non-negative input."
+      name: showIntAtBase
+      within: []
+    - message: "Partial: throws on negative numbers. Ensure non-negative input."
+      name: showInt
+      within: []
+    - message: "Partial: throws on negative numbers. Ensure non-negative input."
+      name: showHex
+      within: []
+    - message: "Partial: throws on negative numbers. Ensure non-negative input."
+      name: showOct
+      within: []
+    - message: "Partial: throws on negative numbers. Ensure non-negative input."
+      name: showBin
+      within: []
+- functions:
     - message: "O(n^2) complexity. Use ordNub or nubOrd instead."
       name: nub
       within: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 ### Added
 
 - `Numeric` re-export in `Himari.Prelude` for extra numeric functions
+- HLint rules to warn against partial functions re-exported from `Numeric`:
+  `showIntAtBase`, `showInt`, `showHex`, `showOct`, and `showBin`,
+  which throw on negative (or invalid base) input
 
 ## [1.1.0.0] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- `Numeric` re-export in `Himari.Prelude` for extra numeric functions
+
 ## [1.1.0.0] - 2026-04-11
 
 ### Added

--- a/example/anomaly-monitor/Anomaly.hs
+++ b/example/anomaly-monitor/Anomaly.hs
@@ -6,7 +6,6 @@ module Anomaly
   ) where
 
 import Himari
-import Numeric
 
 -- | Severity level of detected anomaly.
 data AnomalySeverity

--- a/example/anomaly-monitor/Cpu.hs
+++ b/example/anomaly-monitor/Cpu.hs
@@ -13,7 +13,6 @@ import Data.Text.IO qualified as T
 import Data.Text.Read qualified as T
 import Env
 import Himari
-import Numeric
 
 -- | CPU time statistics from `/proc/stat`.
 data CpuStats = CpuStats

--- a/example/anomaly-monitor/Loop.hs
+++ b/example/anomaly-monitor/Loop.hs
@@ -7,7 +7,6 @@ import Config
 import Cpu
 import Env
 import Himari
-import Numeric
 
 -- | Run monitoring loop.
 monitorLoop

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -43,6 +43,7 @@ reexports:
   - module Himari.Prelude exports "base" Data.Void
   - module Himari.Prelude exports "base" Data.Word
   - module Himari.Prelude exports "base" GHC.Stack
+  - module Himari.Prelude exports "base" Numeric
   - module Himari.Prelude exports "base" Numeric.Natural
   - module Himari.Prelude exports "base" Prelude
   - module Himari.Prelude exports "base" Text.Show

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -18,6 +18,7 @@ let rules
       # ./rules/extensions.dhall
       # ./rules/lens.dhall
       # ./rules/mtl.dhall
+      # ./rules/numeric.dhall
       # ./rules/performance.dhall
       # ./rules/pretty-simple.dhall
       # ./rules/primitive.dhall

--- a/hlint/rules/numeric.dhall
+++ b/hlint/rules/numeric.dhall
@@ -1,0 +1,40 @@
+-- Numeric module partial functions
+-- These integer-showing functions throw on negative (or invalid base) input.
+-- Names are unqualified so re-exports through Himari are caught as well.
+-- The float-showing functions (showEFloat etc.) clamp negative precision and stay total.
+let Types = ../Types.dhall
+
+let Builder = ../Builder.dhall
+
+let showIntAtBaseMessage =
+      "Partial: throws on base <= 1 or negative input. Ensure base > 1 and non-negative input."
+
+let showIntAtBase =
+      Builder.restrictFunction "showIntAtBase" showIntAtBaseMessage
+
+let showIntMessage =
+      "Partial: throws on negative numbers. Ensure non-negative input."
+
+let showInt = Builder.restrictFunction "showInt" showIntMessage
+
+let showHexMessage =
+      "Partial: throws on negative numbers. Ensure non-negative input."
+
+let showHex = Builder.restrictFunction "showHex" showHexMessage
+
+let showOctMessage =
+      "Partial: throws on negative numbers. Ensure non-negative input."
+
+let showOct = Builder.restrictFunction "showOct" showOctMessage
+
+let showBinMessage =
+      "Partial: throws on negative numbers. Ensure non-negative input."
+
+let showBin = Builder.restrictFunction "showBin" showBinMessage
+
+let rules
+    : List Types.Rule
+    = [ Builder.functions [ showIntAtBase, showInt, showHex, showOct, showBin ]
+      ]
+
+in  rules

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -54,6 +54,7 @@ import Himari.Prelude.Process as Export
 import Himari.Prelude.Safe as Export
 import Himari.Prelude.Type as Export
 import Himari.Prelude.TypeLevel as Export
+import Numeric as Export
 import Numeric.Natural as Export
 import Text.Pretty.Simple as Export
 import Text.Show as Export

--- a/test/HlintBaseSpec.hs
+++ b/test/HlintBaseSpec.hs
@@ -25,6 +25,22 @@ spec = do
       itWithOuter "Debug.Trace.traceM should suggest pTraceM" $ \output -> do
         output `shouldSatisfy` containsWarningAt "traceM" "pTraceM"
 
+    describe "Numeric integer-showing functions are partial" $ do
+      itWithOuter "showHex should warn (partial function)" $ \output -> do
+        output `shouldSatisfy` containsWarningAt "showHex" "non-negative"
+
+      itWithOuter "showInt should warn (partial function)" $ \output -> do
+        output `shouldSatisfy` containsWarningAt "showInt" "non-negative"
+
+      itWithOuter "showOct should warn (partial function)" $ \output -> do
+        output `shouldSatisfy` containsWarningAt "showOct" "non-negative"
+
+      itWithOuter "showBin should warn (partial function)" $ \output -> do
+        output `shouldSatisfy` containsWarningAt "showBin" "non-negative"
+
+      itWithOuter "showIntAtBase should warn (partial function)" $ \output -> do
+        output `shouldSatisfy` containsWarningAt "showIntAtBase" "base > 1"
+
 runHlintOnSample :: IO Text
 runHlintOnSample = do
   (exitCode, stdoutOutput, stderrOutput) <-

--- a/test/HlintSamples/BasePartial.hs
+++ b/test/HlintSamples/BasePartial.hs
@@ -4,6 +4,7 @@
 -- This file intentionally uses partial functions to test hlint rules
 module HlintSamples.BasePartial where
 
+import Data.Char (intToDigit) -- test only partial functions
 import Data.List qualified as L
 import Data.List.NonEmpty qualified as NE
 import Debug.Trace (trace, traceM, traceShow)
@@ -29,3 +30,20 @@ useTraceShow x = traceShow x x
 
 useTraceM :: IO ()
 useTraceM = traceM "debug"
+
+-- Numeric integer-showing functions are partial (throw on negative input)
+useShowHex :: Int -> String
+useShowHex n = showHex n ""
+
+useShowInt :: Int -> String
+useShowInt n = showInt n ""
+
+useShowOct :: Int -> String
+useShowOct n = showOct n ""
+
+useShowBin :: Int -> String
+useShowBin n = showBin n ""
+
+-- A base of 12 avoids hlint suggesting showHex/showOct/showBin
+useShowIntAtBase :: Int -> String
+useShowIntAtBase n = showIntAtBase 12 intToDigit n ""


### PR DESCRIPTION
`Himari.Prelude`から`Numeric`モジュールを再エクスポートするようにします。

exampleを書いている中で`Numeric`の関数が頻繁に必要になることがわかったため、
標準でエクスポートに含めておくと利便性が高いと判断しました。

`Numeric`はbaseのモジュールなので依存関係の問題は発生しません。
`read`系の関数も失敗時には空リストを返すため例外を投げず、
部分関数ではないので安全に扱えます。
命名的にも他のモジュールと衝突する可能性は低いと考えています。

あわせて、
himari本体が`Numeric`を標準でエクスポートするようになったことで、
exampleでの`Numeric`の個別importが重複となり警告が出るようになったため、
不要になったimportを削除しています。
