### PR TITLE
refactor: Safe Haskellアノテーションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- Safe Haskell annotations.
+  Modules that expose only safe APIs and import only safe modules are marked `Safe`;
+  they disable `TemplateHaskell`, `DerivingVia`, and `GeneralizedNewtypeDeriving`,
+  which are enabled globally but not allowed under Safe Haskell.
+  Modules that expose only safe APIs but cannot be inferred `Safe`
+  (because a dependency is not marked safe,
+  or because they use Template Haskell or `GeneralizedNewtypeDeriving` internally)
+  are marked `Trustworthy`.
+
 ## [1.1.1.0] - 2026-05-24
 
 ### Added

--- a/src/Himari/Char.hs
+++ b/src/Himari/Char.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- | Safe alternatives to partial functions from "Data.Char".
 module Himari.Char
   ( digitToIntMay

--- a/src/Himari/Env.hs
+++ b/src/Himari/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- | Core environment monad for Himari.
 module Himari.Env
   ( Himari (..)

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- | 基本的な環境を提供するモジュール。
 -- 単純に実行だけをしたい場合、これで十分結果を手に入れられることが多いです。
 module Himari.Env.Simple

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- | Logger utilities for Himari.
 module Himari.Logger
   ( HasLogAction (..)

--- a/src/Himari/Prelude/Arrow.hs
+++ b/src/Himari/Prelude/Arrow.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "Control.Arrow" re-exports, hiding symbols that conflict with "Data.Bifunctor".
 module Himari.Prelude.Arrow
   ( module Export

--- a/src/Himari/Prelude/Catch.hs
+++ b/src/Himari/Prelude/Catch.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | Re-exports from "Control.Monad.Catch" that don't conflict with "UnliftIO".
 --
 -- Functions that conflict with "UnliftIO" are hidden.

--- a/src/Himari/Prelude/Category.hs
+++ b/src/Himari/Prelude/Category.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "Control.Category" re-exports, hiding symbols that conflict with "Prelude".
 module Himari.Prelude.Category
   ( module Export

--- a/src/Himari/Prelude/Data.hs
+++ b/src/Himari/Prelude/Data.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "Data.Data" re-exports, hiding symbols that conflict with "GHC.Generics".
 module Himari.Prelude.Data
   ( module Export

--- a/src/Himari/Prelude/FilePath.hs
+++ b/src/Himari/Prelude/FilePath.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "System.FilePath" re-exports, hiding symbols that conflict with "Control.Lens".
 module Himari.Prelude.FilePath
   ( module Export

--- a/src/Himari/Prelude/Generics.hs
+++ b/src/Himari/Prelude/Generics.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "GHC.Generics" re-exports, hiding symbols that conflict with "Control.Lens".
 module Himari.Prelude.Generics
   ( module Export

--- a/src/Himari/Prelude/Monoid.hs
+++ b/src/Himari/Prelude/Monoid.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "Data.Monoid" and "Data.Semigroup" re-exports, hiding conflicting symbols.
 module Himari.Prelude.Monoid
   ( module Export

--- a/src/Himari/Prelude/Safe.hs
+++ b/src/Himari/Prelude/Safe.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE NoDerivingVia #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoTemplateHaskell #-}
+
 -- | "Safe", "Safe.Exact", and "Safe.Foldable" re-exports.
 -- Only total functions are exported; partial functions are hidden.
 -- "Safe.Foldable" is preferred for more generic versions,

--- a/src/Himari/Prelude/Type.hs
+++ b/src/Himari/Prelude/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Trustworthy #-}
+
 -- | Type-only re-exports from various modules.
 --
 -- Includes types from "Data.ByteString", "Data.HashMap.Strict",


### PR DESCRIPTION
`src`配下の各モジュールにSafe Haskellの分類を言語拡張で明示します。
利用者が各モジュールの安全性を把握しやすくするためです。

安全なAPIのみを公開し、
importも安全なモジュールに限られるものは`Safe`にしました。
グローバルに有効な`TemplateHaskell`/`DerivingVia`/`GeneralizedNewtypeDeriving`は、
Safe Haskellで許可されないため、
これらのモジュールでは個別に無効化しています。

公開APIは安全でも`Safe`に推論できないものは`Trustworthy`にしました。
`Char`/`Logger`/`Env`/`Env.Simple`/`Type`が該当します。
依存モジュールがsafeとマークされていない、
あるいはTemplate Haskellや`GeneralizedNewtypeDeriving`を内部で使うことが理由です。

`Himari.Prelude`と`Himari`、
および`Aeson`/`Process`/`TypeLevel`は、
あえて無注釈のままにしてUnsafe扱いとしました。

`Himari.Prelude`は`Control.Monad.Primitive`の`unsafeInlineIO`や、
`Data.Coerce`の`coerce`を再exportしており、
`Trustworthy`を名乗るとSafeなコードへ危険な関数を漏らす嘘の保証になるためです。

`Aeson`/`Process`/`TypeLevel`は外部モジュールを丸ごと再exportしているため、
公開シンボルすべてが安全だと確信が持てず、
保守的にUnsafe扱いとしました。
