### PR TITLE
feat: ログ出力のデフォルト実装を共通化しSimpleEnvの生成と実行を分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ### Added
 
-- `newSimpleEnv` export in `Himari.Env.Simple` to construct a `SimpleEnv`
+- `mkSimpleEnv` export in `Himari.Env.Simple` to construct a `SimpleEnv`
   with the default settings separately from running it
 - `defaultMonadLoggerLog` export in `Himari.Logger`,
   a reusable `monadLoggerLog` implementation for any `HasLogAction` environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
   with the default settings separately from running it
 - `defaultMonadLoggerLog` export in `Himari.Logger`,
   a reusable `monadLoggerLog` implementation for any `HasLogAction` environment
-- `mkDefaultLogAction` export in `Himari.Logger`
+- `defaultLogAction` export in `Himari.Logger`
   for the default `LogAction` that writes to standard error
 - Safe Haskell annotations.
   Modules that expose only safe APIs and import only safe modules are marked `Safe`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ### Added
 
+- `newSimpleEnv` export in `Himari.Env.Simple` to construct a `SimpleEnv`
+  with the default settings separately from running it
+- `defaultMonadLoggerLog` export in `Himari.Logger`,
+  a reusable `monadLoggerLog` implementation for any `HasLogAction` environment
+- `mkDefaultLogAction` export in `Himari.Logger`
+  for the default `LogAction` that writes to standard error
 - Safe Haskell annotations.
   Modules that expose only safe APIs and import only safe modules are marked `Safe`;
   they disable `TemplateHaskell`, `DerivingVia`, and `GeneralizedNewtypeDeriving`,

--- a/example/anomaly-monitor/Cpu.hs
+++ b/example/anomaly-monitor/Cpu.hs
@@ -86,7 +86,7 @@ readCpuStats = do
     Right content -> pure $ parseCpuStats content
 
 -- | Format CPU threshold and other config values as text.
-showIOCpuThreshold :: (MonadIO m, MonadReader MonitorEnv m) => m Text
+showIOCpuThreshold :: (MonadIO m, MonadReader Env m) => m Text
 showIOCpuThreshold = do
   config' <- view config
   return $

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -23,9 +23,7 @@ makeFieldsId ''MonitorEnv
 -- | Enable MonadLogger for our custom environment.
 -- This is the key instance that allows us to use logging functions.
 instance MonadLogger (Himari MonitorEnv) where
-  monadLoggerLog loc src level msg = do
-    logAction' <- view logAction
-    liftIO . logAction' loc src level $ toLogStr msg
+  monadLoggerLog = defaultMonadLoggerLog
 
 -- | Create the monitoring environment by loading configuration from command line arguments.
 newEnv :: (MonadIO m) => m MonitorEnv

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -1,5 +1,5 @@
 module Env
-  ( MonitorEnv (..)
+  ( Env (..)
   , HasLogAction (..)
   , HasConfig (..)
   , newEnv
@@ -10,7 +10,7 @@ import Himari
 
 -- | Custom environment for the monitoring application.
 -- This demonstrates how to create your own Env instead of using SimpleEnv.
-data MonitorEnv = MonitorEnv
+data Env = Env
   { logAction :: LogAction
   -- ^ Log output function.
   , config :: MonitorConfig
@@ -18,17 +18,17 @@ data MonitorEnv = MonitorEnv
   }
   deriving (Generic)
 
-makeFieldsId ''MonitorEnv
+makeFieldsId ''Env
 
 -- | Enable MonadLogger for our custom environment.
 -- This is the key instance that allows us to use logging functions.
-instance MonadLogger (Himari MonitorEnv) where
+instance MonadLogger (Himari Env) where
   monadLoggerLog = defaultMonadLoggerLog
 
--- | Create the monitoring environment by loading configuration from command line arguments.
-newEnv :: (MonadIO m) => m MonitorEnv
+-- | Create the application environment by loading configuration from command line arguments.
+newEnv :: (MonadIO m) => m Env
 newEnv = do
   -- Get config file path from command line args (optional)
   args <- getArgs
   config' <- runSimpleEnv . loadConfig $ listToMaybe args
-  return $ MonitorEnv{logAction = mkDefaultLogAction, config = config'}
+  return $ Env{logAction = mkDefaultLogAction, config = config'}

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -31,4 +31,4 @@ newEnv = do
   -- Get config file path from command line args (optional)
   args <- getArgs
   config' <- runSimpleEnv . loadConfig $ listToMaybe args
-  return $ Env{logAction = mkDefaultLogAction, config = config'}
+  return $ Env{logAction = defaultLogAction, config = config'}

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -30,6 +30,5 @@ newEnv :: (MonadIO m) => m MonitorEnv
 newEnv = do
   -- Get config file path from command line args (optional)
   args <- getArgs
-  let logAction' = defaultOutput stderr -- use stderr for logging
   config' <- runSimpleEnv . loadConfig $ listToMaybe args
-  return $ MonitorEnv{logAction = logAction', config = config'}
+  return $ MonitorEnv{logAction = mkDefaultLogAction, config = config'}

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -2,7 +2,7 @@ module Env
   ( MonitorEnv (..)
   , HasLogAction (..)
   , HasConfig (..)
-  , mkEnv
+  , newEnv
   ) where
 
 import Config
@@ -28,8 +28,8 @@ instance MonadLogger (Himari MonitorEnv) where
     liftIO . logAction' loc src level $ toLogStr msg
 
 -- | Create the monitoring environment by loading configuration from command line arguments.
-mkEnv :: (MonadIO m) => m MonitorEnv
-mkEnv = do
+newEnv :: (MonadIO m) => m MonitorEnv
+newEnv = do
   -- Get config file path from command line args (optional)
   args <- getArgs
   let logAction' = defaultOutput stderr -- use stderr for logging

--- a/example/anomaly-monitor/Loop.hs
+++ b/example/anomaly-monitor/Loop.hs
@@ -10,7 +10,7 @@ import Himari
 
 -- | Run monitoring loop.
 monitorLoop
-  :: (MonadLogger m, MonadReader MonitorEnv m, MonadUnliftIO m)
+  :: (MonadLogger m, MonadReader Env m, MonadUnliftIO m)
   => CpuStats
   -> Int
   -> m ()

--- a/example/anomaly-monitor/Main.hs
+++ b/example/anomaly-monitor/Main.hs
@@ -15,5 +15,5 @@ import Run
 -- | Main entry point.
 main :: IO ()
 main = do
-  initialEnv <- mkEnv
+  initialEnv <- newEnv
   runHimari initialEnv runAnomalyMonitor

--- a/example/anomaly-monitor/Run.hs
+++ b/example/anomaly-monitor/Run.hs
@@ -9,7 +9,7 @@ import Himari
 import Loop
 
 -- | Run application.
-runAnomalyMonitor :: (MonadLogger m, MonadReader MonitorEnv m, MonadUnliftIO m) => m ()
+runAnomalyMonitor :: (MonadLogger m, MonadReader Env m, MonadUnliftIO m) => m ()
 runAnomalyMonitor = do
   logInfoN "Initializing Anomaly Monitoring System..."
   printBanner

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -27,11 +27,19 @@ instance MonadLogger (Himari SimpleEnv) where
     logAction' <- view logAction
     liftIO . logAction' loc src level $ toLogStr msg
 
--- | `SimpleEnv`をデフォルト設定で実行する。
+-- | `SimpleEnv`のコンテキストのアクションをデフォルト設定で実行します。
 runSimpleEnv :: (MonadIO m) => Himari SimpleEnv a -> m a
-runSimpleEnv = runSimpleEnvWith $ defaultOutput stderr
+runSimpleEnv f = do
+  env <- newSimpleEnv
+  runHimari env f
 
--- | `SimpleEnv`をカスタム出力で実行します。
+-- | `SimpleEnv`をデフォルト設定で作成します。
+newSimpleEnv :: (MonadIO m) => m SimpleEnv
+newSimpleEnv = do
+  let logAction' = defaultOutput stderr
+  return $ SimpleEnv{logAction = logAction'}
+
+-- | `SimpleEnv`のコンテキストのアクションをカスタム出力で実行します。
 runSimpleEnvWith
   :: (MonadIO m)
   => LogAction

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -6,7 +6,7 @@ module Himari.Env.Simple
   ( SimpleEnv
   , runSimpleEnv
   , runSimpleEnvWith
-  , newSimpleEnv
+  , mkSimpleEnv
   ) where
 
 import Himari.Env
@@ -29,7 +29,7 @@ instance MonadLogger (Himari SimpleEnv) where
 -- | `SimpleEnv`のコンテキストのアクションをデフォルト設定で実行します。
 runSimpleEnv :: (MonadIO m) => Himari SimpleEnv a -> m a
 runSimpleEnv f = do
-  env <- newSimpleEnv
+  env <- mkSimpleEnv
   runHimari env f
 
 -- | `SimpleEnv`のコンテキストのアクションをカスタム出力で実行します。
@@ -45,5 +45,5 @@ runSimpleEnvWith
 runSimpleEnvWith logAction' = runHimari (SimpleEnv logAction')
 
 -- | `SimpleEnv`をデフォルト設定で作成します。
-newSimpleEnv :: (MonadIO m) => m SimpleEnv
-newSimpleEnv = return $ SimpleEnv{logAction = defaultLogAction}
+mkSimpleEnv :: (MonadIO m) => m SimpleEnv
+mkSimpleEnv = return $ SimpleEnv{logAction = defaultLogAction}

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -35,7 +35,9 @@ runSimpleEnv = runSimpleEnvWith $ defaultOutput stderr
 runSimpleEnvWith
   :: (MonadIO m)
   => LogAction
-  -- ^ ログの出力方法。例えば`defaultOutput stdout`にすれば標準出力にログが出力されます。
+  -- ^ ログの出力方法。
+  -- 例えば`defaultOutput stderr`にすれば標準エラー出力にログが出力されます。
+  -- `defaultOutput stdout`にすれば標準出力にログが出力されます。
   -> Himari SimpleEnv a
   -- ^ 実行したいアクション。
   -> m a

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -6,6 +6,7 @@ module Himari.Env.Simple
   ( SimpleEnv
   , runSimpleEnv
   , runSimpleEnvWith
+  , newSimpleEnv
   ) where
 
 import Himari.Env
@@ -31,10 +32,6 @@ runSimpleEnv f = do
   env <- newSimpleEnv
   runHimari env f
 
--- | `SimpleEnv`をデフォルト設定で作成します。
-newSimpleEnv :: (MonadIO m) => m SimpleEnv
-newSimpleEnv = return $ SimpleEnv{logAction = mkDefaultLogAction}
-
 -- | `SimpleEnv`のコンテキストのアクションをカスタム出力で実行します。
 runSimpleEnvWith
   :: (MonadIO m)
@@ -46,3 +43,7 @@ runSimpleEnvWith
   -- ^ 実行したいアクション。
   -> m a
 runSimpleEnvWith logAction' = runHimari (SimpleEnv logAction')
+
+-- | `SimpleEnv`をデフォルト設定で作成します。
+newSimpleEnv :: (MonadIO m) => m SimpleEnv
+newSimpleEnv = return $ SimpleEnv{logAction = mkDefaultLogAction}

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -35,9 +35,7 @@ runSimpleEnv f = do
 
 -- | `SimpleEnv`をデフォルト設定で作成します。
 newSimpleEnv :: (MonadIO m) => m SimpleEnv
-newSimpleEnv = do
-  let logAction' = defaultOutput stderr
-  return $ SimpleEnv{logAction = logAction'}
+newSimpleEnv = return $ SimpleEnv{logAction = mkDefaultLogAction}
 
 -- | `SimpleEnv`のコンテキストのアクションをカスタム出力で実行します。
 runSimpleEnvWith

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -23,9 +23,7 @@ newtype SimpleEnv = SimpleEnv
 makeFieldsId ''SimpleEnv
 
 instance MonadLogger (Himari SimpleEnv) where
-  monadLoggerLog loc src level msg = do
-    logAction' <- view logAction
-    liftIO . logAction' loc src level $ toLogStr msg
+  monadLoggerLog = defaultMonadLoggerLog
 
 -- | `SimpleEnv`のコンテキストのアクションをデフォルト設定で実行します。
 runSimpleEnv :: (MonadIO m) => Himari SimpleEnv a -> m a

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -46,4 +46,4 @@ runSimpleEnvWith logAction' = runHimari (SimpleEnv logAction')
 
 -- | `SimpleEnv`をデフォルト設定で作成します。
 newSimpleEnv :: (MonadIO m) => m SimpleEnv
-newSimpleEnv = return $ SimpleEnv{logAction = mkDefaultLogAction}
+newSimpleEnv = return $ SimpleEnv{logAction = defaultLogAction}

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -4,6 +4,7 @@
 module Himari.Logger
   ( HasLogAction (..)
   , LogAction
+  , defaultMonadLoggerLog
   , mkDefaultLogAction
   ) where
 
@@ -18,6 +19,12 @@ class HasLogAction s a | s -> a where
 -- | ログ出力を行う関数の型。
 -- 出力をカスタムしたい場合、このシグネチャに合わせた関数を作成するとやりやすい。
 type LogAction = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
+
+-- | "MonadLogger".'monadLoggerLog'に渡せるデフォルトの実装。
+defaultMonadLoggerLog :: (MonadIO m, ToLogStr msg) => Loc -> LogSource -> LogLevel -> msg -> m ()
+defaultMonadLoggerLog loc src level msg = do
+  let logAction' = mkDefaultLogAction
+  liftIO . logAction' loc src level $ toLogStr msg
 
 -- | デフォルトのログ出力。
 -- 標準エラー出力にログを出力します。

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -4,6 +4,7 @@
 module Himari.Logger
   ( HasLogAction (..)
   , LogAction
+  , mkDefaultLogAction
   ) where
 
 import Himari.Prelude
@@ -17,3 +18,8 @@ class HasLogAction s a | s -> a where
 -- | ログ出力を行う関数の型。
 -- 出力をカスタムしたい場合、このシグネチャに合わせた関数を作成するとやりやすい。
 type LogAction = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
+
+-- | デフォルトのログ出力。
+-- 標準エラー出力にログを出力します。
+mkDefaultLogAction :: LogAction
+mkDefaultLogAction = defaultOutput stderr

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -5,7 +5,7 @@ module Himari.Logger
   ( HasLogAction (..)
   , LogAction
   , defaultMonadLoggerLog
-  , mkDefaultLogAction
+  , defaultLogAction
   ) where
 
 import Himari.Env
@@ -31,5 +31,5 @@ defaultMonadLoggerLog loc src level msg = do
 
 -- | デフォルトのログ出力。
 -- 標準エラー出力にログを出力します。
-mkDefaultLogAction :: LogAction
-mkDefaultLogAction = defaultOutput stderr
+defaultLogAction :: LogAction
+defaultLogAction = defaultOutput stderr

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -9,7 +9,8 @@ module Himari.Logger
 import Himari.Prelude
 
 -- | ログ出力を行う能力があることを検査するための型クラス。
--- lensと互換性を持たせているので適切にフィールド名を設定してTemplate Haskellで生成すれば自動で実装されます。
+-- lensと互換性を持たせているので適切にフィールド名を設定して、
+-- Template Haskellで生成すれば自動で実装されます。
 class HasLogAction s a | s -> a where
   logAction :: Lens' s a
 

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -8,6 +8,7 @@ module Himari.Logger
   , mkDefaultLogAction
   ) where
 
+import Himari.Env
 import Himari.Prelude
 
 -- | ログ出力を行う能力があることを検査するための型クラス。
@@ -21,9 +22,11 @@ class HasLogAction s a | s -> a where
 type LogAction = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
 
 -- | "MonadLogger".'monadLoggerLog'に渡せるデフォルトの実装。
-defaultMonadLoggerLog :: (MonadIO m, ToLogStr msg) => Loc -> LogSource -> LogLevel -> msg -> m ()
+defaultMonadLoggerLog
+  :: (HasLogAction env LogAction, ToLogStr msg)
+  => Loc -> LogSource -> LogLevel -> msg -> Himari env ()
 defaultMonadLoggerLog loc src level msg = do
-  let logAction' = mkDefaultLogAction
+  logAction' <- view logAction
   liftIO . logAction' loc src level $ toLogStr msg
 
 -- | デフォルトのログ出力。


### PR DESCRIPTION
ライブラリ利用者が自分の環境型に対して`MonadLogger`を実装する際の定型処理を、
`Himari.Logger`の共通関数として提供します。

`HasLogAction`を満たす任意の環境で使える`monadLoggerLog`の実装として`defaultMonadLoggerLog`を、
標準エラー出力へ書き出すデフォルトの`LogAction`として`mkDefaultLogAction`を追加します。
これまで`SimpleEnv`の`MonadLogger`インスタンスに直接書いていたロジックを、
利用者が自分の環境型でも再利用できる形に切り出すのが目的です。

あわせて`Himari.Env.Simple`では`SimpleEnv`の生成と実行を分離し、
デフォルト設定で`SimpleEnv`を作る`newSimpleEnv`をexportします。
連続して関数を呼び出すときに環境を使い回せるようにするためです。

`example`配下も新しいAPIに追従させ、
副作用のある生成関数は`mk`より`new`が適切なため`mkEnv`を`newEnv`へ、
アプリケーションの型名として自然な`MonitorEnv`を`Env`へリネームしています。