### PR TITLE
build(deps): cabalのindex-stateを更新

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 with-compiler: ghc-9.12.2
-index-state: 2026-01-11T22:34:12Z
+index-state: 2026-05-23T22:37:37Z
 packages: .
 
 package himari


### PR DESCRIPTION
`cabal.project`の`index-state`を`2026-05-23T22:37:37Z`に更新しました。
