### PR TITLE
ci: GitHub Actionsワークフローのコメントと整形を改善

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
         os:
           - ubuntu-24.04 # x86_64-linux
           - ubuntu-24.04-arm # aarch64-linux
-          - macos-15 # Apple Silicon (aarch64-darwin)
+          - macos-15 # aarch64-darwin
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read # Read repository contents
@@ -45,7 +45,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      # バージョンは一つに絞られてしまいますが、他のnix-flake-checkジョブで十分カバーできているので問題ありません。
+      # バージョンは一つに絞られてしまいますが、
+      # 他のnix-flake-checkジョブで十分カバーできているので問題ありません。
       - name: Extract GHC version from cabal.project
         id: ghc
         shell: bash
@@ -65,7 +66,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
-          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}-plan-${{ hashFiles('**/plan.json') }} # editorconfig-checker-disable-line
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}-plan-${{ hashFiles('**/plan.json') }}
           restore-keys: |
             ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}-
       - run: cabal test --disable-optimization --enable-tests
@@ -75,8 +76,9 @@ jobs:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
+  # `nix flake check`で対応していないチェックを行う。
   format:
-    name: format # nix flake checkで実行されるnix fmtで対応していない範囲のフォーマットチェックを行う。
+    name: format
     runs-on: ubuntu-24.04
     permissions:
       contents: read # Read repository contents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,16 @@ jobs:
           ref: "${{ github.event.workflow_run.head_sha }}"
           persist-credentials: false
           fetch-depth: 0 # タグの存在確認と作成に全履歴が必要
-      - name: Check cabal file changed # workflow_runでpathsフィルタは使えないので、ジョブ内でのチェックが必要になります。
+      # `workflow_run`で`paths`フィルタは使えないので、
+      # ジョブ内でのチェックが必要になります。
+      - name: Check cabal file changed #
         id: changed
         run: |
           set -euo pipefail
-          # 最新のリリースタグを取得(なければ全履歴を対象)
-          LAST_TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+          # 最新のリリースタグを取得。
+          # なければ全履歴が対象。
+          LAST_TAG=$(git describe --tags --match 'v*' --abbrev=0 ||
+                     git rev-list --max-parents=0 HEAD)
           if git diff --name-only "$LAST_TAG" HEAD -- '*.cabal' | grep -q '.cabal'; then
             echo "cabal_changed=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0 # タグの存在確認と作成に全履歴が必要
       # `workflow_run`で`paths`フィルタは使えないので、
       # ジョブ内でのチェックが必要になります。
-      - name: Check cabal file changed #
+      - name: Check cabal file changed
         id: changed
         run: |
           set -euo pipefail


### PR DESCRIPTION
動作変更は標準エラー出力を無視しないようにしたことぐらいです。
無視しないほうが望ましいと思うし、
やたらと長い行を短縮出来ます。
