### PR TITLE
feat: GHCのサポート範囲に`9.12.3`と`9.12.4`を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+## [1.1.2.1] - 2026-05-25
+
+### Added
+
+- GHC 9.12.3 and 9.12.4 support
+
 ## [1.1.2.0] - 2026-05-25
 
 ### Added

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-with-compiler: ghc-9.12.2
+with-compiler: ghc-9.12.4
 index-state: 2026-05-23T22:37:37Z
 packages: .
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       changelog-lint-src,
     }:
     let
-      ghc-version = "ghc9122"; # GHC 9.12.2
+      ghc-version = "ghc9124"; # GHC 9.12.4
       cabal-version = "3.16.1.0";
       hls-version = "2.12.0.0";
       overlays = [
@@ -120,6 +120,9 @@
             flake.variants = {
               ghc9102.compiler-nix-name = final.lib.mkDefault "ghc9102"; # GHC 9.10.2
               ghc9103.compiler-nix-name = final.lib.mkDefault "ghc9103"; # GHC 9.10.3
+              ghc9122.compiler-nix-name = final.lib.mkDefault "ghc9122"; # GHC 9.12.2
+              ghc9123.compiler-nix-name = final.lib.mkDefault "ghc9123"; # GHC 9.12.3
+              # 9.12.4はデフォルト選択なので省略。
               ghc9141.compiler-nix-name = final.lib.mkDefault "ghc9141"; # GHC 9.14.1
             };
             shell = {

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,19 @@
                   );
                 }
               )
+              # テストはhlintを外部プログラムとして`proc "hlint"`で呼び出します。
+              # `build-tool-depends`でhlintをHackageからビルドさせると、
+              # その依存であるghc-lib-parserをプロジェクトのGHCで再コンパイルすることになり、
+              # ghc-lib-parserのスナップショットとGHCのバージョンが食い違うと、
+              # コンパイルできず壊れます。
+              #
+              # 例: `ghc-lib-parser-9.12.2`を`GHC 9.12.4`でビルドすると、
+              # `GHC.Internal.TH.Ppr`が見つからない。
+              #
+              # そのためHLS経由で用意済みの動作実績のあるhlintをテストのPATHに供給します。
+              {
+                packages.himari.components.tests.himari-test.build-tools = [ final.hlint ];
+              }
             ];
             # `ghc-version`だけではなく、
             # `variants`で定義したGHCバージョンも`nix flake check`で自動的にテストされます。

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     let
       ghc-version = "ghc9124"; # GHC 9.12.4
       cabal-version = "3.16.1.0";
-      hls-version = "2.12.0.0";
+      hls-version = "2.13.0.0";
       overlays = [
         haskellNix.overlay
         (
@@ -128,7 +128,7 @@
             shell = {
               tools = {
                 cabal = cabal-version;
-                cabal-gild = "1.6.0.2"; # treefmtで管理されているが広く使えるように。
+                cabal-gild = "1.6.0.4"; # treefmtで管理されているが広く使えるように。
                 haskell-language-server = hls-version;
                 implicit-hie = "0.1.4.0";
               };
@@ -239,7 +239,7 @@
                 pkgs.writeShellApplication {
                   name = "cabal-gild-wrapper";
                   runtimeInputs = [
-                    (pkgs.haskell-nix.tool ghc-version "cabal-gild" "1.6.0.2")
+                    (pkgs.haskell-nix.tool ghc-version "cabal-gild" "1.6.0.4")
                     pkgs.git
                     pkgs.parallel
                   ];

--- a/himari.cabal
+++ b/himari.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.12
 name: himari
-version: 1.1.2.0
+version: 1.1.2.1
 synopsis: A standard library for Haskell as an alternative to rio
 description:
   A standard library for Haskell inspired by rio.
@@ -30,6 +30,8 @@ tested-with:
   ghc ==9.10.2
   ghc ==9.10.3
   ghc ==9.12.2
+  ghc ==9.12.3
+  ghc ==9.12.4
   ghc ==9.14.1
 
 source-repository head

--- a/himari.cabal
+++ b/himari.cabal
@@ -161,9 +161,6 @@ test-suite himari-test
     himari,
     sydtest >=0.18.0.0 && <0.24,
 
-  build-tool-depends:
-    hlint:hlint ^>=3.10
-
 executable anomaly-monitor
   import: basic
   hs-source-dirs: example/anomaly-monitor


### PR DESCRIPTION
サポート対象のGHCに`9.12.3`と`9.12.4`を追加します。
`GHC 9.12`系で最新の`9.12.4`をデフォルト選択にして、
他のバージョンはバリアントとしてビルド・テストするようにします。

デフォルトGHCを`9.12.4`へ上げた際に、
テストの`build-tool-depends`で参照していたhlintのビルドが壊れました。
`build-tool-depends`で参照するとhlintとその依存の`ghc-lib-parser`がプロジェクトのGHCで再コンパイルされ、
ソルバが本体とのリンクを優先して古いスナップショットを選ぶため、
`ghc-lib-parser-9.12.2`系が`GHC 9.12.4`でコンパイルできず壊れていました。
テストはhlintを外部プログラムとして呼び出しているだけなので、
HLS経由で用意済みの動作実績のあるhlintをテストのPATHに供給する方式へ切り替えました。
これによりhlintのビルドがGHCのバージョンに連動しなくなり、
全てのGHCバリアントで安定してテストを実行できます。

あわせてパッチバージョンを`1.1.2.1`へ上げ、
CHANGELOGにサポートGHCの拡張を記載しました。