### PR TITLE
ci: Windows CIでhlint-setupアクションを追加

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,7 @@ jobs:
         id: setup
         with:
           ghc-version: ${{ steps.ghc.outputs.version }}
+      - uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2.4.10
       - name: Configure and generate build plan
         run: |
           cabal configure --disable-optimization --enable-tests


### PR DESCRIPTION
[feat: GHCのサポート範囲に`9.12.3`と`9.12.4`を追加 by ncaq · Pull Request #214 · ncaq/himari](https://github.com/ncaq/himari/pull/214)
での変更により、
非Nix環境ではhlintを手動で入れる必要が発生したため。
hlintの全体実行自体は他のジョブで行えばいいので、
runまでは行いません。
