### PR TITLE
fix: nixpkgs純粋空間でテストがhlintの依存を解決できずに失敗する問題を解消

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,6 @@ jobs:
         id: setup
         with:
           ghc-version: ${{ steps.ghc.outputs.version }}
-      - uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2.4.10
       - name: Configure and generate build plan
         run: |
           cabal configure --disable-optimization --enable-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Changed
+
+- Relax `time` dependency upper bound from `^>=1.12.2` to `>=1.12.2 && <2`
+  to allow building against future `time` 1.x releases
+- Declare `hlint ^>=3.10` as `build-tool-depends` for the test suite
+  so `cabal test` no longer requires `hlint` to be pre-installed on `PATH`
+- Constrain `ghc-lib-parser >=9.12.3` for the test suite under GHC `>=9.12.3`
+  to avoid an unbuildable install plan with `ghc-lib-parser-9.12.2`
+  (which fails on GHC `>=9.12.3` because `GHC.Internal.TH.Ppr` was removed).
+  See <https://github.com/digital-asset/ghc-lib/issues/624>
+  and <https://github.com/ndmitchell/hlint/pull/1696>
+
 ## [1.1.2.1] - 2026-05-25
 
 ### Added

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,3 +7,5 @@ HSA = "HSA"
 Hashi = "Hashi"
 # Immediately Invoked Function Expression (IIFE)の略語。camelCase分割で"IIF"をtypoと判定する。
 IIF = "IIF"
+# `Data.Bifunctor`
+bimap = "bimap"

--- a/flake.lock
+++ b/flake.lock
@@ -202,7 +202,9 @@
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
         "nixpkgs-2511": "nixpkgs-2511",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs-unstable": [
+          "nixpkgs"
+        ],
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
@@ -492,16 +494,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779467186,
-        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -598,22 +600,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-25.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,8 @@
                 deadnix
                 editorconfig-checker
                 final.changelog-lint
+                fourmolu
+                hlint
                 nixfmt-rfc-style
                 prettier
                 shellcheck
@@ -173,8 +175,6 @@
                 dhall-yaml
 
                 # Haskell関連ツール。
-                fourmolu
-                hlint
                 parallel
                 zlib # aesonを開発環境でビルド。
 

--- a/flake.nix
+++ b/flake.nix
@@ -116,19 +116,6 @@
                   );
                 }
               )
-              # テストはhlintを外部プログラムとして`proc "hlint"`で呼び出します。
-              # `build-tool-depends`でhlintをHackageからビルドさせると、
-              # その依存であるghc-lib-parserをプロジェクトのGHCで再コンパイルすることになり、
-              # ghc-lib-parserのスナップショットとGHCのバージョンが食い違うと、
-              # コンパイルできず壊れます。
-              #
-              # 例: `ghc-lib-parser-9.12.2`を`GHC 9.12.4`でビルドすると、
-              # `GHC.Internal.TH.Ppr`が見つからない。
-              #
-              # そのためHLS経由で用意済みの動作実績のあるhlintをテストのPATHに供給します。
-              {
-                packages.himari.components.tests.himari-test.build-tools = [ final.hlint ];
-              }
             ];
             # `ghc-version`だけではなく、
             # `variants`で定義したGHCバージョンも`nix flake check`で自動的にテストされます。

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
@@ -8,7 +8,12 @@
         nixpkgs.follows = "nixpkgs";
       };
     };
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix = {
+      url = "github:input-output-hk/haskell.nix";
+      inputs = {
+        nixpkgs-unstable.follows = "nixpkgs";
+      };
+    };
     changelog-lint-src = {
       url = "git+https://codeberg.org/chavacava/changelog-lint.git";
       flake = false;

--- a/himari.cabal
+++ b/himari.cabal
@@ -178,9 +178,6 @@ test-suite himari-test
     -- See https://github.com/digital-asset/ghc-lib/issues/624
     build-depends:
       ghc-lib-parser >=9.12.3
-  else
-    build-depends:
-      ghc-lib-parser ==9.12.*
 
 executable anomaly-monitor
   import: basic

--- a/himari.cabal
+++ b/himari.cabal
@@ -164,6 +164,20 @@ test-suite himari-test
   build-tool-depends:
     hlint:hlint ^>=3.10
 
+  -- hlint経由のghc-lib-parserの参照バージョンに問題が出やすいので、
+  -- こちら側でヒントを出して誘導します。
+  -- [ghc-lib-parser bound to forbid 9.12.2 on `GHC >= 9.12.3`](https://github.com/ndmitchell/hlint/pull/1696)
+  if impl(ghc >=9.12.3)
+    -- ghc-lib-parser 9.12.2 does not build with GHC >= 9.12.3
+    -- (`GHC.Internal.TH.Ppr` was removed).
+    -- Require >= 9.12.3 to avoid producing an unbuildable install plan.
+    -- See https://github.com/digital-asset/ghc-lib/issues/624
+    build-depends:
+      ghc-lib-parser >=9.12.3 && <9.13
+  else
+    build-depends:
+      ghc-lib-parser ==9.12.*
+
 executable anomaly-monitor
   import: basic
   hs-source-dirs: example/anomaly-monitor

--- a/himari.cabal
+++ b/himari.cabal
@@ -161,6 +161,9 @@ test-suite himari-test
     himari,
     sydtest >=0.18.0.0 && <0.24,
 
+  build-tool-depends:
+    hlint:hlint ^>=3.10
+
 executable anomaly-monitor
   import: basic
   hs-source-dirs: example/anomaly-monitor

--- a/himari.cabal
+++ b/himari.cabal
@@ -177,7 +177,7 @@ test-suite himari-test
     -- Require >= 9.12.3 to avoid producing an unbuildable install plan.
     -- See https://github.com/digital-asset/ghc-lib/issues/624
     build-depends:
-      ghc-lib-parser >=9.12.3 && <9.13
+      ghc-lib-parser >=9.12.3
   else
     build-depends:
       ghc-lib-parser ==9.12.*

--- a/himari.cabal
+++ b/himari.cabal
@@ -102,7 +102,7 @@ common basic
     retry ^>=0.9.3.1,
     safe ^>=0.3.21,
     text ^>=2.1.2,
-    time ^>=1.12.2,
+    time >=1.12.2 && <2,
     typed-process ^>=0.2.13.0,
     unliftio ^>=0.2.25.1,
     unordered-containers ^>=0.2.20,

--- a/himari.cabal
+++ b/himari.cabal
@@ -166,7 +166,11 @@ test-suite himari-test
 
   -- hlint経由のghc-lib-parserの参照バージョンに問題が出やすいので、
   -- こちら側でヒントを出して誘導します。
-  -- [ghc-lib-parser bound to forbid 9.12.2 on `GHC >= 9.12.3`](https://github.com/ndmitchell/hlint/pull/1696)
+  -- <https://github.com/ndmitchell/hlint/pull/1696>
+  -- で既にhlint側に問題提起しているため、
+  -- それが解決するか、
+  -- hlintの使用ライブラリがGHC 9.14系統に変われば、
+  -- この条件は削除して問題ありません。
   if impl(ghc >=9.12.3)
     -- ghc-lib-parser 9.12.2 does not build with GHC >= 9.12.3
     -- (`GHC.Internal.TH.Ppr` was removed).


### PR DESCRIPTION
[feat: GHCのサポート範囲に`9.12.3`と`9.12.4`を追加 by ncaq · Pull Request #214 · ncaq/himari](https://github.com/ncaq/himari/pull/214)
でhlintをcabalの`build-tool-depends`から外し、
`flake.nix`側でテストのPATHに外部供給する方式に切り替えました。
しかしこれだとnixpkgsの純粋空間でのテストが依存関係を追いきれず失敗します。
これを修正するために、
hlintをcabal経由の依存に戻し、
あわせて関連するビルド設定を整理します。

まずnixpkgsを`nixos-25.11`から`nixos-unstable`に切り替えました。
問題のない`ghc-lib-parser`はstableには含まれていなかったからです。
それによってソルバが異様に古いバージョンを選ぶことを危惧しました。

アプリケーションならともかく、
ライブラリという性質上、
最新のHackageに追従できるunstable側で開発したほうが、
最新のGHCやライブラリをサポートしやすく、
むしろ好都合だと判断しました。

また決定的な制約として、
cabalファイル側で`GHC 9.12.3`以降に対して`ghc-lib-parser >=9.12.3`を要求しました。
これによりソルバが誤ったバージョンを選ぶのを防止します。
上限はhlintが`GHC 9.14`系統に依存するように切り替わっても、
問題なく通るよう外しておきます。

ついでに以下も整理しました。

- `fourmolu`と`hlint`をtreefmtツール側へ移動し、原則を守る配置に統一
- `time`の依存上限を`^>=1.12.2`から`>=1.12.2 && <2`へ緩和
  (Haskell PvPに従っていない以上、範囲指定のほうが妥当)
- `_typos.toml`に`bimap`を追加して`Data.Bifunctor`の関数名がtypo判定されないように
- `[Unreleased]`セクションのCHANGELOGを更新

close #218
