### PR TITLE
build: data-defaultのバージョン下限を0.8.0.0に緩和

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Changed
+
+- Relax `data-default` dependency lower bound from `^>=0.8.0.2` to `^>=0.8.0.0`
+  to widen the range of compatible `data-default` 0.8.x releases
+
 ## [1.1.2.2] - 2026-05-28
 
 ### Changed

--- a/himari.cabal
+++ b/himari.cabal
@@ -88,7 +88,7 @@ common basic
     bytestring ^>=0.12.2.0,
     containers ^>=0.7,
     convertible ^>=1.1.1.1,
-    data-default ^>=0.8.0.2,
+    data-default ^>=0.8.0.0,
     deepseq ^>=1.5.0.0,
     deriving-aeson ^>=0.2.10,
     exceptions ^>=0.10.9,


### PR DESCRIPTION
[data-default/Changes.md at main - mauke/data-default - Codeberg.org](https://codeberg.org/mauke/data-default/src/branch/main/Changes.md)
を見る限り、
このpatchにあたっては大した変更は無いように見えるので、
ソルバ任せにして問題ありません。
nixpkgsの`25.11`にあるdata-defaultが`0.8.0.1`なので、
それを受け入れるようにします。
