### PR TITLE
refactor: `default-extensions`から無効化候補の言語拡張を外す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 - Relax `data-default` dependency lower bound from `^>=0.8.0.2` to `^>=0.8.0.0`
   to widen the range of compatible `data-default` 0.8.x releases
+- Remove `DerivingVia` and `TemplateHaskell` from `default-extensions`
+  and enable them only in modules that use them,
+  so `Safe` modules no longer need `NoDerivingVia` and `NoTemplateHaskell` overrides
 
 ## [1.1.2.2] - 2026-05-28
 

--- a/example/anomaly-monitor/Config.hs
+++ b/example/anomaly-monitor/Config.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module Config
   ( MonitorConfig (..)
   , HasCpuThreshold (..)

--- a/example/anomaly-monitor/Env.hs
+++ b/example/anomaly-monitor/Env.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Env
   ( Env (..)
   , HasLogAction (..)

--- a/himari.cabal
+++ b/himari.cabal
@@ -54,7 +54,6 @@ common basic
     BlockArguments
     CPP
     DefaultSignatures
-    DerivingVia
     DuplicateRecordFields
     FunctionalDependencies
     LexicalNegation
@@ -75,7 +74,6 @@ common basic
     RecordWildCards
     RecursiveDo
     StrictData
-    TemplateHaskell
     TypeData
     TypeFamilies
     TypeFamilyDependencies

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 
 -- | 基本的な環境を提供するモジュール。

--- a/src/Himari/Prelude/Arrow.hs
+++ b/src/Himari/Prelude/Arrow.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "Control.Arrow" re-exports, hiding symbols that conflict with "Data.Bifunctor".
 module Himari.Prelude.Arrow

--- a/src/Himari/Prelude/Catch.hs
+++ b/src/Himari/Prelude/Catch.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | Re-exports from "Control.Monad.Catch" that don't conflict with "UnliftIO".
 --

--- a/src/Himari/Prelude/Category.hs
+++ b/src/Himari/Prelude/Category.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "Control.Category" re-exports, hiding symbols that conflict with "Prelude".
 module Himari.Prelude.Category

--- a/src/Himari/Prelude/Data.hs
+++ b/src/Himari/Prelude/Data.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "Data.Data" re-exports, hiding symbols that conflict with "GHC.Generics".
 module Himari.Prelude.Data

--- a/src/Himari/Prelude/FilePath.hs
+++ b/src/Himari/Prelude/FilePath.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "System.FilePath" re-exports, hiding symbols that conflict with "Control.Lens".
 module Himari.Prelude.FilePath

--- a/src/Himari/Prelude/Generics.hs
+++ b/src/Himari/Prelude/Generics.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "GHC.Generics" re-exports, hiding symbols that conflict with "Control.Lens".
 module Himari.Prelude.Generics

--- a/src/Himari/Prelude/Monoid.hs
+++ b/src/Himari/Prelude/Monoid.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "Data.Monoid" and "Data.Semigroup" re-exports, hiding conflicting symbols.
 module Himari.Prelude.Monoid

--- a/src/Himari/Prelude/Safe.hs
+++ b/src/Himari/Prelude/Safe.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE NoDerivingVia #-}
 {-# LANGUAGE NoGeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoTemplateHaskell #-}
 
 -- | "Safe", "Safe.Exact", and "Safe.Foldable" re-exports.
 -- Only total functions are exported; partial functions are hidden.

--- a/test/Himari/Env/SimpleSpec.hs
+++ b/test/Himari/Env/SimpleSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module Himari.Env.SimpleSpec (spec) where
 
 import Himari


### PR DESCRIPTION
`DerivingVia`と`TemplateHaskell`は`Safe`マーク付きの8モジュールで個別に`No`接頭辞で無効化されており、
スッキリしないため`default-extensions`から外して使用箇所でのみ有効にする方針へ切り替えます。

- `himari.cabal`の`default-extensions`から`DerivingVia`と`TemplateHaskell`を削除
- `src/Himari/Prelude`配下の`Safe`モジュールから対応する`NoDerivingVia`と`NoTemplateHaskell`を削除
- `TemplateHaskell`を実際に使う`Himari.Env.Simple`、
  `example/anomaly-monitor`の`Env`と`Config`、`Himari.Env.SimpleSpec`に追加
- `DerivingVia`を使う`example/anomaly-monitor/Config`に追加

`GeneralizedNewtypeDeriving`はGHC2024由来で`default-extensions`には載っていないため、
今回の対象からは外して各モジュールの`NoGeneralizedNewtypeDeriving`は残しています。
