### PR TITLE
feat: ログを破棄するログ出力APIを追加してテスト時のターミナル出力を抑制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - `discardLogAction` export in `Himari.Logger`,
   a `LogAction` that discards all log output,
   useful for tests that should not write logs to the real terminal
+- `runSimpleNoLogEnv` export in `Himari.Env.Simple`,
+  a shorthand for `runSimpleEnvWith discardLogAction`
+  that runs a `SimpleEnv` action while discarding all log output
 
 ## [1.1.3.0] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- `discardLogAction` export in `Himari.Logger`,
+  a `LogAction` that discards all log output,
+  useful for tests that should not write logs to the real terminal
+
 ## [1.1.3.0] - 2026-05-30
 
 ### Added

--- a/src/Himari/Env/Simple.hs
+++ b/src/Himari/Env/Simple.hs
@@ -6,6 +6,7 @@
 module Himari.Env.Simple
   ( SimpleEnv
   , runSimpleEnv
+  , runSimpleNoLogEnv
   , runSimpleEnvWith
   , mkSimpleEnv
   ) where
@@ -32,6 +33,11 @@ runSimpleEnv :: (MonadIO m) => Himari SimpleEnv a -> m a
 runSimpleEnv f = do
   env <- mkSimpleEnv
   runHimari env f
+
+-- | `SimpleEnv`のコンテキストのアクションをログを破棄して実行します。
+-- テストなど実際のターミナルにログを出力したくない場合に使えます。
+runSimpleNoLogEnv :: (MonadIO m) => Himari SimpleEnv a -> m a
+runSimpleNoLogEnv = runSimpleEnvWith discardLogAction
 
 -- | `SimpleEnv`のコンテキストのアクションをカスタム出力で実行します。
 runSimpleEnvWith

--- a/src/Himari/Logger.hs
+++ b/src/Himari/Logger.hs
@@ -7,6 +7,7 @@ module Himari.Logger
   , LogAction
   , defaultMonadLoggerLog
   , defaultLogAction
+  , discardLogAction
   ) where
 
 import Himari.Env
@@ -35,3 +36,8 @@ defaultMonadLoggerLog loc src level msg = do
 -- 標準エラー出力にログを出力します。
 defaultLogAction :: LogAction
 defaultLogAction = defaultOutput stderr
+
+-- | ログを一切出力せず破棄するログ出力。
+-- テストなどで実際のターミナルにログを出力したくない場合に使えます。
+discardLogAction :: LogAction
+discardLogAction _loc _src _level _msg = pure ()

--- a/test/Himari/Env/SimpleSpec.hs
+++ b/test/Himari/Env/SimpleSpec.hs
@@ -7,26 +7,30 @@ import Test.Syd
 
 spec :: Spec
 spec = do
+  -- テスト実行時に実際のターミナルへログを出力すると、
+  -- Errorなどがログディスプレイでハイライトされて紛らわしいので、
+  -- ログの出力を検証しないテストでは`discardLogAction`で出力を破棄する。
   describe "logging" $ do
     it
       "outputs debug level logs"
-      (runSimpleEnv $ $(logDebug) "debug message" :: IO ())
+      (runSimpleEnvWith discardLogAction $ $(logDebug) "debug message" :: IO ())
 
     it
       "outputs info level logs"
-      (runSimpleEnv $ $(logInfo) "info message" :: IO ())
+      (runSimpleEnvWith discardLogAction $ $(logInfo) "info message" :: IO ())
 
     it
       "outputs warning level logs"
-      (runSimpleEnv $ $(logWarn) "warning message" :: IO ())
+      (runSimpleEnvWith discardLogAction $ $(logWarn) "warning message" :: IO ())
 
     it
       "outputs error level logs"
-      (runSimpleEnv $ $(logError) "error message" :: IO ())
+      (runSimpleEnvWith discardLogAction $ $(logError) "error message" :: IO ())
 
     it
       "handles multiple log calls"
-      ( runSimpleEnv
+      ( runSimpleEnvWith
+          discardLogAction
           ( do
               $(logInfo) "first log"
               $(logInfo) "second log"
@@ -36,7 +40,7 @@ spec = do
       )
 
     it "works with monadic composition" $ do
-      result <- runSimpleEnv $ do
+      result <- runSimpleEnvWith discardLogAction $ do
         $(logInfo) "starting computation"
         let x = 20 :: Int
         $(logDebug) ("intermediate value: " <> convert (show x))
@@ -47,7 +51,8 @@ spec = do
 
     it
       "supports monad-logger functions"
-      ( runSimpleEnv
+      ( runSimpleEnvWith
+          discardLogAction
           ( do
               logInfoN "using logInfoN"
               logDebugN "using logDebugN"
@@ -85,7 +90,7 @@ spec = do
       result `shouldBe` 42
 
     it "can access and use the environment" $ do
-      result <- runSimpleEnv $ do
+      result <- runSimpleEnvWith discardLogAction $ do
         $(logInfo) "computing result"
         pure (10 + 32 :: Int)
       result `shouldBe` 42

--- a/test/Himari/Env/SimpleSpec.hs
+++ b/test/Himari/Env/SimpleSpec.hs
@@ -9,28 +9,27 @@ spec :: Spec
 spec = do
   -- テスト実行時に実際のターミナルへログを出力すると、
   -- Errorなどがログディスプレイでハイライトされて紛らわしいので、
-  -- ログの出力を検証しないテストでは`discardLogAction`で出力を破棄する。
+  -- ログの出力を検証しないテストでは`runSimpleNoLogEnv`で出力を破棄する。
   describe "logging" $ do
     it
       "outputs debug level logs"
-      (runSimpleEnvWith discardLogAction $ $(logDebug) "debug message" :: IO ())
+      (runSimpleNoLogEnv $ $(logDebug) "debug message" :: IO ())
 
     it
       "outputs info level logs"
-      (runSimpleEnvWith discardLogAction $ $(logInfo) "info message" :: IO ())
+      (runSimpleNoLogEnv $ $(logInfo) "info message" :: IO ())
 
     it
       "outputs warning level logs"
-      (runSimpleEnvWith discardLogAction $ $(logWarn) "warning message" :: IO ())
+      (runSimpleNoLogEnv $ $(logWarn) "warning message" :: IO ())
 
     it
       "outputs error level logs"
-      (runSimpleEnvWith discardLogAction $ $(logError) "error message" :: IO ())
+      (runSimpleNoLogEnv $ $(logError) "error message" :: IO ())
 
     it
       "handles multiple log calls"
-      ( runSimpleEnvWith
-          discardLogAction
+      ( runSimpleNoLogEnv
           ( do
               $(logInfo) "first log"
               $(logInfo) "second log"
@@ -40,7 +39,7 @@ spec = do
       )
 
     it "works with monadic composition" $ do
-      result <- runSimpleEnvWith discardLogAction $ do
+      result <- runSimpleNoLogEnv $ do
         $(logInfo) "starting computation"
         let x = 20 :: Int
         $(logDebug) ("intermediate value: " <> convert (show x))
@@ -51,8 +50,7 @@ spec = do
 
     it
       "supports monad-logger functions"
-      ( runSimpleEnvWith
-          discardLogAction
+      ( runSimpleNoLogEnv
           ( do
               logInfoN "using logInfoN"
               logDebugN "using logDebugN"
@@ -90,7 +88,7 @@ spec = do
       result `shouldBe` 42
 
     it "can access and use the environment" $ do
-      result <- runSimpleEnvWith discardLogAction $ do
+      result <- runSimpleNoLogEnv $ do
         $(logInfo) "computing result"
         pure (10 + 32 :: Int)
       result `shouldBe` 42


### PR DESCRIPTION
ログモジュールのテストは`runSimpleEnv`経由でデフォルトの`defaultLogAction`を使うため、
テスト実行時に実際の標準エラー出力へログが流れていました。
特にErrorログがターミナルのログディスプレイでハイライトされてしまい、
失敗と紛らわしく感じられる問題がありました。

これを解消するために、ログ出力を無効化するためのAPIを追加します。

- `Himari.Logger`にログを一切出力せず破棄する`discardLogAction`を追加します。
  任意の`HasLogAction`環境で使える汎用的な`LogAction`です。
- `Himari.Env.Simple`に`runSimpleEnvWith discardLogAction`のショートハンドである、
  `runSimpleNoLogEnv`を追加します。
  `SimpleEnv`のアクションをログを破棄して実行したい場面で簡潔に書けます。

合わせて、出力内容自体を検証しないログモジュールのスモークテストを`runSimpleNoLogEnv`へ切り替え、
テスト時に実際のターミナルへログを出さないようにしました。

close #229
