### PR TITLE
build(deps): cabalのindex-stateを更新

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 with-compiler: ghc-9.12.4
-index-state: 2026-05-23T22:37:37Z
+index-state: 2026-06-06T23:03:51Z
 packages: .
 
 package himari


### PR DESCRIPTION
`cabal.project`の`index-state`を`2026-06-06T23:03:51Z`に更新しました。
