### PR TITLE
build(deps): aesonの上限を緩めて2.3系を受け入れる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
   a shorthand for `runSimpleEnvWith discardLogAction`
   that runs a `SimpleEnv` action while discarding all log output
 
+### Changed
+
+- Relax `aeson` dependency upper bound from `^>=2.2.3.0` to `^>=2.2.3.0 || ^>=2.3.0.0`
+  to allow building against `aeson` 2.3.y.z
+
 ## [1.1.3.0] - 2026-05-30
 
 ### Added

--- a/himari.cabal
+++ b/himari.cabal
@@ -80,7 +80,7 @@ common basic
     ViewPatterns
 
   build-depends:
-    aeson ^>=2.2.3.0,
+    aeson ^>=2.2.3.0 || ^>=2.3.0.0,
     aeson-pretty ^>=0.8.10,
     base >=4.19.2.0 && <4.23,
     bytestring ^>=0.12.2.0,


### PR DESCRIPTION
himariライブラリ自身は`aeson`を再エクスポートしているだけで、
独自の`FromJSON`や`ToJSON`の定義を持たないため、
`aeson 2.3`系で入った変更による非互換はありません。
実際に`--allow-newer`で`aeson 2.3.0.0`に対してビルドとテストを通したところ、
96件のテストが全て通ることを確認済みです。

そこで`himari.cabal`の`aeson`制約を`^>=2.2.3.0`から`^>=2.2.3.0 || ^>=2.3.0.0`へ緩和します。

なお現状は`deriving-aeson`と`aeson-pretty`の上限が`aeson 2.3`を受け付けないため、
この緩和だけでは実際に`2.3`系で解決できるようにはなりませんが、
himari側に非互換が無いことを先に記録しておく意図です。

`CHANGELOG.md`の`[Unreleased]`にも依存関係の変更として追記しています。