### PR TITLE
feat(Himari.SafePrelude): timeの未re-export公開モジュール11個を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - `runSimpleNoLogEnv` export in `Himari.Env.Simple`,
   a shorthand for `runSimpleEnvWith discardLogAction`
   that runs a `SimpleEnv` action while discarding all log output
+- Re-export all public `time` modules that `Data.Time` itself does not re-export
+  in `Himari.SafePrelude`:
+  `Data.Time.Calendar.Easter`,
+  `Data.Time.Calendar.Julian`,
+  `Data.Time.Calendar.MonthDay`,
+  `Data.Time.Calendar.Month`,
+  `Data.Time.Calendar.OrdinalDate`,
+  `Data.Time.Calendar.Quarter`,
+  `Data.Time.Calendar.WeekDate`,
+  `Data.Time.Clock.POSIX`,
+  `Data.Time.Clock.System`,
+  `Data.Time.Clock.TAI`,
+  `Data.Time.Format.ISO8601`,
+  and register them in the `fourmolu.yaml` `reexports` setting
 
 ### Changed
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -60,6 +60,17 @@ reexports:
   - module Himari.Prelude exports "pretty-simple" Text.Pretty.Simple
   - module Himari.Prelude exports "primitive" Control.Monad.Primitive
   - module Himari.Prelude exports "time" Data.Time
+  - module Himari.Prelude exports "time" Data.Time.Calendar.Easter
+  - module Himari.Prelude exports "time" Data.Time.Calendar.Julian
+  - module Himari.Prelude exports "time" Data.Time.Calendar.Month
+  - module Himari.Prelude exports "time" Data.Time.Calendar.MonthDay
+  - module Himari.Prelude exports "time" Data.Time.Calendar.OrdinalDate
+  - module Himari.Prelude exports "time" Data.Time.Calendar.Quarter
+  - module Himari.Prelude exports "time" Data.Time.Calendar.WeekDate
+  - module Himari.Prelude exports "time" Data.Time.Clock.POSIX
+  - module Himari.Prelude exports "time" Data.Time.Clock.System
+  - module Himari.Prelude exports "time" Data.Time.Clock.TAI
+  - module Himari.Prelude exports "time" Data.Time.Format.ISO8601
   - module Himari.Prelude exports "unliftio" UnliftIO
   - module Himari.Prelude exports "unliftio" UnliftIO.Concurrent
   - module Himari.Prelude exports "unliftio" UnliftIO.Directory

--- a/src/Himari/SafePrelude.hs
+++ b/src/Himari/SafePrelude.hs
@@ -38,6 +38,17 @@ import Data.Proxy as Export
 import Data.Ratio as Export
 import Data.String as Export
 import Data.Time as Export
+import Data.Time.Calendar.Easter as Export
+import Data.Time.Calendar.Julian as Export
+import Data.Time.Calendar.Month as Export
+import Data.Time.Calendar.MonthDay as Export
+import Data.Time.Calendar.OrdinalDate as Export
+import Data.Time.Calendar.Quarter as Export
+import Data.Time.Calendar.WeekDate as Export
+import Data.Time.Clock.POSIX as Export
+import Data.Time.Clock.System as Export
+import Data.Time.Clock.TAI as Export
+import Data.Time.Format.ISO8601 as Export
 import Data.Traversable as Export
 import Data.Tuple as Export
 import Data.Void as Export


### PR DESCRIPTION
timeパッケージの`Data.Time`がre-exportしているのは、
`Data.Time.Calendar`と`Data.Time.Clock`と`Data.Time.LocalTime`と`Data.Time.Format`の4つだけで、
`iso8601Show`などを使うには利用者が個別にimportする必要がありました。

`Data.Time`から到達できない公開モジュール11個、

- `Data.Time.Calendar.Easter`
- `Data.Time.Calendar.Julian`
- `Data.Time.Calendar.Month`
- `Data.Time.Calendar.MonthDay`
- `Data.Time.Calendar.OrdinalDate`
- `Data.Time.Calendar.Quarter`
- `Data.Time.Calendar.WeekDate`
- `Data.Time.Clock.POSIX`
- `Data.Time.Clock.System`
- `Data.Time.Clock.TAI`
- `Data.Time.Format.ISO8601`

を`Himari.SafePrelude`でre-exportします。
これで`import Himari`だけで`iso8601Show`や`POSIXTime`や`Month`なども使えるようになります。

既存のre-export群との名前衝突はありません。
重複して見える名前(`isLeapYear`や`getCurrentTime`や月名パターンなど)は、
全て同一エンティティの再exportなので問題になりません。
11モジュール全てが`Safe`マーク付きなので`Himari.SafePrelude`のSafe性も維持されます。
cabalの`time >=1.12.2 && <2`の範囲についても、
`1.12.2`から`1.16`までの全リリースでモジュールの存在とSafe性を確認し、
boot timeが異なるGHC `9.10`と`9.12`と`9.14`に加えて、
最新の`1.16`でもコンパイルが通ることを検証済みです。

利用者にも配布される`fourmolu.yaml`の`reexports`設定にも11モジュールを登録し、
`CHANGELOG.md`の`[Unreleased]`にも追記しています。