### PR TITLE
fix(fourmolu): reexportsチェーンを`Himari.SafePrelude`導入後の構造に合わせる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - Relax `aeson` dependency upper bound from `^>=2.2.3.0` to `^>=2.2.3.0 || ^>=2.3.0.0`
   to allow building against `aeson` 2.3.y.z
 
+### Fixed
+
+- Restructure the `fourmolu.yaml` `reexports` chain to match the module hierarchy
+  introduced with `Himari.SafePrelude` in 1.1.3.0:
+  re-exports that moved to `Himari.SafePrelude` are now registered under it
+  instead of `Himari.Prelude`,
+  and the previously missing `Data.Default` and `UnliftIO.Retry` entries are added
+
 ## [1.1.3.0] - 2026-05-30
 
 ### Added

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -17,79 +17,85 @@ reexports:
   - module Himari exports "himari" Himari.Prelude
 
   # Himari.Prelude → 外部モジュール
-  - module Himari.Prelude exports "base" Control.Applicative
-  - module Himari.Prelude exports "base" Control.Monad
-  - module Himari.Prelude exports "base" Control.Monad.ST
-  - module Himari.Prelude exports "base" Data.Bifoldable
-  - module Himari.Prelude exports "base" Data.Bitraversable
-  - module Himari.Prelude exports "base" Data.Bool
   - module Himari.Prelude exports "base" Data.Coerce
-  - module Himari.Prelude exports "base" Data.Complex
-  - module Himari.Prelude exports "base" Data.Either
-  - module Himari.Prelude exports "base" Data.Eq
-  - module Himari.Prelude exports "base" Data.Fixed
-  - module Himari.Prelude exports "base" Data.Foldable
-  - module Himari.Prelude exports "base" Data.Function
-  - module Himari.Prelude exports "base" Data.Functor.Compose
-  - module Himari.Prelude exports "base" Data.Int
-  - module Himari.Prelude exports "base" Data.Kind
-  - module Himari.Prelude exports "base" Data.Maybe
-  - module Himari.Prelude exports "base" Data.Ord
-  - module Himari.Prelude exports "base" Data.Proxy
-  - module Himari.Prelude exports "base" Data.Ratio
-  - module Himari.Prelude exports "base" Data.String
-  - module Himari.Prelude exports "base" Data.Traversable
-  - module Himari.Prelude exports "base" Data.Tuple
-  - module Himari.Prelude exports "base" Data.Void
-  - module Himari.Prelude exports "base" Data.Word
-  - module Himari.Prelude exports "base" GHC.Stack
-  - module Himari.Prelude exports "base" Numeric
-  - module Himari.Prelude exports "base" Numeric.Natural
-  - module Himari.Prelude exports "base" Prelude
-  - module Himari.Prelude exports "base" Text.Show
-  - module Himari.Prelude exports "convertible" Data.Convertible
-  - module Himari.Prelude exports "deepseq" Control.DeepSeq
-  - module Himari.Prelude exports "hashable" Data.Hashable
-  - module Himari.Prelude exports "lens" Control.Lens
-  - module Himari.Prelude exports "monad-logger" Control.Monad.Logger
-  - module Himari.Prelude exports "mtl" Control.Monad.Cont
-  - module Himari.Prelude exports "mtl" Control.Monad.Reader
-  - module Himari.Prelude exports "mtl" Control.Monad.State.Strict
-  - module Himari.Prelude exports "mtl" Control.Monad.Writer.CPS
   - module Himari.Prelude exports "pretty-simple" Debug.Pretty.Simple
-  - module Himari.Prelude exports "pretty-simple" Text.Pretty.Simple
   - module Himari.Prelude exports "primitive" Control.Monad.Primitive
-  - module Himari.Prelude exports "time" Data.Time
-  - module Himari.Prelude exports "time" Data.Time.Calendar.Easter
-  - module Himari.Prelude exports "time" Data.Time.Calendar.Julian
-  - module Himari.Prelude exports "time" Data.Time.Calendar.Month
-  - module Himari.Prelude exports "time" Data.Time.Calendar.MonthDay
-  - module Himari.Prelude exports "time" Data.Time.Calendar.OrdinalDate
-  - module Himari.Prelude exports "time" Data.Time.Calendar.Quarter
-  - module Himari.Prelude exports "time" Data.Time.Calendar.WeekDate
-  - module Himari.Prelude exports "time" Data.Time.Clock.POSIX
-  - module Himari.Prelude exports "time" Data.Time.Clock.System
-  - module Himari.Prelude exports "time" Data.Time.Clock.TAI
-  - module Himari.Prelude exports "time" Data.Time.Format.ISO8601
+  - module Himari.Prelude exports "retry" UnliftIO.Retry
   - module Himari.Prelude exports "unliftio" UnliftIO
   - module Himari.Prelude exports "unliftio" UnliftIO.Concurrent
   - module Himari.Prelude exports "unliftio" UnliftIO.Directory
-  - module Himari.Prelude exports "unliftio" UnliftIO.Environment
   - module Himari.Prelude exports "unliftio" UnliftIO.Exception.Lens
   - module Himari.Prelude exports "unliftio" UnliftIO.IO.File
   # Himari.Prelude → 内部サブモジュール
   - module Himari.Prelude exports "himari" Himari.Prelude.Aeson
-  - module Himari.Prelude exports "himari" Himari.Prelude.Arrow
-  - module Himari.Prelude exports "himari" Himari.Prelude.Catch
-  - module Himari.Prelude exports "himari" Himari.Prelude.Category
-  - module Himari.Prelude exports "himari" Himari.Prelude.Data
-  - module Himari.Prelude exports "himari" Himari.Prelude.FilePath
-  - module Himari.Prelude exports "himari" Himari.Prelude.Generics
-  - module Himari.Prelude exports "himari" Himari.Prelude.Monoid
   - module Himari.Prelude exports "himari" Himari.Prelude.Process
-  - module Himari.Prelude exports "himari" Himari.Prelude.Safe
-  - module Himari.Prelude exports "himari" Himari.Prelude.Type
   - module Himari.Prelude exports "himari" Himari.Prelude.TypeLevel
+  - module Himari.Prelude exports "himari" Himari.SafePrelude
+
+  # Himari.SafePrelude → 外部モジュール
+  - module Himari.SafePrelude exports "base" Control.Applicative
+  - module Himari.SafePrelude exports "base" Control.Monad
+  - module Himari.SafePrelude exports "base" Control.Monad.ST
+  - module Himari.SafePrelude exports "base" Data.Bifoldable
+  - module Himari.SafePrelude exports "base" Data.Bitraversable
+  - module Himari.SafePrelude exports "base" Data.Bool
+  - module Himari.SafePrelude exports "base" Data.Complex
+  - module Himari.SafePrelude exports "base" Data.Either
+  - module Himari.SafePrelude exports "base" Data.Eq
+  - module Himari.SafePrelude exports "base" Data.Fixed
+  - module Himari.SafePrelude exports "base" Data.Foldable
+  - module Himari.SafePrelude exports "base" Data.Function
+  - module Himari.SafePrelude exports "base" Data.Functor.Compose
+  - module Himari.SafePrelude exports "base" Data.Int
+  - module Himari.SafePrelude exports "base" Data.Kind
+  - module Himari.SafePrelude exports "base" Data.Maybe
+  - module Himari.SafePrelude exports "base" Data.Ord
+  - module Himari.SafePrelude exports "base" Data.Proxy
+  - module Himari.SafePrelude exports "base" Data.Ratio
+  - module Himari.SafePrelude exports "base" Data.String
+  - module Himari.SafePrelude exports "base" Data.Traversable
+  - module Himari.SafePrelude exports "base" Data.Tuple
+  - module Himari.SafePrelude exports "base" Data.Void
+  - module Himari.SafePrelude exports "base" Data.Word
+  - module Himari.SafePrelude exports "base" GHC.Stack
+  - module Himari.SafePrelude exports "base" Numeric
+  - module Himari.SafePrelude exports "base" Numeric.Natural
+  - module Himari.SafePrelude exports "base" Prelude
+  - module Himari.SafePrelude exports "base" Text.Show
+  - module Himari.SafePrelude exports "convertible" Data.Convertible
+  - module Himari.SafePrelude exports "data-default" Data.Default
+  - module Himari.SafePrelude exports "deepseq" Control.DeepSeq
+  - module Himari.SafePrelude exports "hashable" Data.Hashable
+  - module Himari.SafePrelude exports "lens" Control.Lens
+  - module Himari.SafePrelude exports "monad-logger" Control.Monad.Logger
+  - module Himari.SafePrelude exports "mtl" Control.Monad.Cont
+  - module Himari.SafePrelude exports "mtl" Control.Monad.Reader
+  - module Himari.SafePrelude exports "mtl" Control.Monad.State.Strict
+  - module Himari.SafePrelude exports "mtl" Control.Monad.Writer.CPS
+  - module Himari.SafePrelude exports "pretty-simple" Text.Pretty.Simple
+  - module Himari.SafePrelude exports "time" Data.Time
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.Easter
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.Julian
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.Month
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.MonthDay
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.OrdinalDate
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.Quarter
+  - module Himari.SafePrelude exports "time" Data.Time.Calendar.WeekDate
+  - module Himari.SafePrelude exports "time" Data.Time.Clock.POSIX
+  - module Himari.SafePrelude exports "time" Data.Time.Clock.System
+  - module Himari.SafePrelude exports "time" Data.Time.Clock.TAI
+  - module Himari.SafePrelude exports "time" Data.Time.Format.ISO8601
+  - module Himari.SafePrelude exports "unliftio" UnliftIO.Environment
+  # Himari.SafePrelude → 内部サブモジュール
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Arrow
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Catch
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Category
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Data
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.FilePath
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Generics
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Monoid
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Safe
+  - module Himari.SafePrelude exports "himari" Himari.Prelude.Type
 
   # Himari.Prelude.Aeson → 外部モジュール
   - module Himari.Prelude.Aeson exports "aeson" Data.Aeson


### PR DESCRIPTION
`1.1.3.0`で`Himari.Prelude`のSafe可能なre-exportを`Himari.SafePrelude`へ分離しましたが、
利用者にも配布される`fourmolu.yaml`の`reexports`設定は旧構造のままで、
全ての外部モジュールが`Himari.Prelude`直下に登録されており、
`Himari.SafePrelude`が一切登場していませんでした。
fourmoluはreexportsをチェーン方式で再帰的に展開するため、
実際のモジュール階層と一致させておくべきです。

実コードのimport構造と突き合わせて、
以下のように再構成します。

- `Himari.Prelude`の登録を実際にre-exportしているモジュールだけに絞る:
  外部はUnliftIO系と`Data.Coerce`と`Debug.Pretty.Simple`と`Control.Monad.Primitive`、
  内部は`Himari.Prelude.Aeson`と`Himari.Prelude.Process`と`Himari.Prelude.TypeLevel`、
  そして`Himari.SafePrelude`
- `Himari.SafePrelude`セクションを新設し、
  baseやtimeやmtlなどの外部41モジュールと、
  `Himari.Prelude.Arrow`などの内部サブモジュール9個を登録

また実コードに存在するのに登録から漏れていた、
`Data.Default`(data-default)と`UnliftIO.Retry`(retry)も追加します。

`nix fmt -- --no-cache`で全ファイルにフォーマッタを実行し、
新しい設定でfourmoluが正常に動作して既存コードに差分が出ないことを確認済みです。
`CHANGELOG.md`の`[Unreleased]`にも`Fixed`として追記しています。