### PR TITLE
docs: `anomaly-monitor`を`example-anomaly-monitor`にrename

### DIFF
--- a/himari.cabal
+++ b/himari.cabal
@@ -178,7 +178,7 @@ test-suite himari-test
     build-depends:
       ghc-lib-parser >=9.12.3
 
-executable anomaly-monitor
+executable example-anomaly-monitor
   import: basic
   hs-source-dirs: example/anomaly-monitor
   main-is: Main.hs


### PR DESCRIPTION
Hackageの画面で見た時に、
あくまでexampleを実行ファイルとして置いているだけに過ぎないと分かり易くするため、
名前自体にexampleというプレフィックスをつけます。
あくまでexampleの改名なのでライブラリとしての動作の変更はありません。
