### PR TITLE
build(deps): 依存バージョン制約を`^>=`から`>=&&<`形式に展開する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Changed
+
+- Switch dependency version bounds from the PVP caret operator (`^>=`)
+  to explicit `>=x && <y` ranges.
+  So that Renovate can recognize and update them.
+
 ## [1.1.4.0] - 2026-06-13
 
 ### Added

--- a/himari.cabal
+++ b/himari.cabal
@@ -80,31 +80,31 @@ common basic
     ViewPatterns
 
   build-depends:
-    aeson ^>=2.2.3.0 || ^>=2.3.0.0,
-    aeson-pretty ^>=0.8.10,
+    aeson >=2.2.3.0 && <2.4,
+    aeson-pretty >=0.8.10 && <0.9,
     base >=4.19.2.0 && <4.23,
-    bytestring ^>=0.12.2.0,
-    containers ^>=0.7,
-    convertible ^>=1.1.1.1,
-    data-default ^>=0.8.0.0,
-    deepseq ^>=1.5.0.0,
-    deriving-aeson ^>=0.2.10,
-    exceptions ^>=0.10.9,
-    filepath ^>=1.5.4.0,
-    hashable ^>=1.5.0.0,
-    lens ^>=5.3.5,
-    monad-logger ^>=0.3.42,
-    mtl ^>=2.3.1,
-    pretty-simple ^>=4.1.3,
-    primitive ^>=0.9.1.0,
-    retry ^>=0.9.3.1,
-    safe ^>=0.3.21,
-    text ^>=2.1.2,
+    bytestring >=0.12.2.0 && <0.13,
+    containers >=0.7 && <0.8,
+    convertible >=1.1.1.1 && <1.2,
+    data-default >=0.8.0.0 && <0.9,
+    deepseq >=1.5.0.0 && <1.6,
+    deriving-aeson >=0.2.10 && <0.3,
+    exceptions >=0.10.9 && <0.11,
+    filepath >=1.5.4.0 && <1.6,
+    hashable >=1.5.0.0 && <1.6,
+    lens >=5.3.5 && <6,
+    monad-logger >=0.3.42 && <0.4,
+    mtl >=2.3.1 && <2.4,
+    pretty-simple >=4.1.3.0 && <4.2,
+    primitive >=0.9.1.0 && <0.10,
+    retry >=0.9.3.1 && <0.10,
+    safe >=0.3.21 && <0.4,
+    text >=2.1.2 && <2.2,
     time >=1.12.2 && <2,
-    typed-process ^>=0.2.13.0,
-    unliftio ^>=0.2.25.1,
-    unordered-containers ^>=0.2.20,
-    vector ^>=0.13.2.0,
+    typed-process >=0.2.13.0 && <0.3,
+    unliftio >=0.2.25.1 && <0.3,
+    unordered-containers >=0.2.20 && <0.3,
+    vector >=0.13.2.0 && <0.14,
 
 library
   import: basic
@@ -156,12 +156,12 @@ test-suite himari-test
     -with-rtsopts=-N
 
   build-depends:
-    QuickCheck ^>=2.15.0.1,
+    QuickCheck >=2.15.0.1 && <2.16,
     himari,
     sydtest >=0.18.0.0 && <0.24,
 
   build-tool-depends:
-    hlint:hlint ^>=3.10
+    hlint:hlint >=3.10 && <4
 
   -- hlint経由のghc-lib-parserの参照バージョンに問題が出やすいので、
   -- こちら側でヒントを出して誘導します。


### PR DESCRIPTION
RenovateのHaskell向けmanager(haskell-cabal)はpvp versioningで依存を更新しますが、
その`parseRange`は`>=x && <y`形式しか解釈できません。
Haskellで慣用的な`^>=`(PVP caret operator)や`||`を含む制約は、
更新がスキップされるか、
範囲を壊す誤った書き換えが行われます。

himariを参照する人がRenovateで依存を自動更新できるように、
`build-depends`の`^>=`を`>=x && <y`形式へ展開します。

- 基本は`^>= A.B.C` ≡ `>= A.B.C && < A.(B+1)`として同じ範囲を保ちます
- `aeson`の`^>=2.2.3.0 || ^>=2.3.0.0`は`||`がRenovateで扱えないため、
  実リリースでは等価な`>=2.2.3.0 && <2.4`へ集約します
- `lens`と`hlint`は上限をメジャー全体(`<6`, `<4`)まで許容します

`CHANGELOG.md`の`[Unreleased]`にも依存制約の変更として追記しています。
