### PR TITLE
build(deps): `containers`の上限を緩めて0.8系を受け入れる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ### Changed
 
+- Widen the `containers` version bound from `<0.8` to `<0.9`
+  to allow `containers` 0.8, which ships with GHC 9.14.
 - Switch dependency version bounds from the PVP caret operator (`^>=`)
   to explicit `>=x && <y` ranges.
   So that Renovate can recognize and update them.

--- a/himari.cabal
+++ b/himari.cabal
@@ -84,7 +84,7 @@ common basic
     aeson-pretty >=0.8.10 && <0.9,
     base >=4.19.2.0 && <4.23,
     bytestring >=0.12.2.0 && <0.13,
-    containers >=0.7 && <0.8,
+    containers >=0.7 && <0.9,
     convertible >=1.1.1.1 && <1.2,
     data-default >=0.8.0.0 && <0.9,
     deepseq >=1.5.0.0 && <1.6,


### PR DESCRIPTION
`containers 0.8`は`GHC 9.14`に同梱されるバージョンです。
himariが`containers`から使っているのは`Himari.Prelude.Type`での、

- `IntMap`
- `IntSet`
- `Map`
- `Seq`
- `Set`
- `Tree`

の型の再エクスポートだけで、
関数や内部モジュール(`Utils.Containers.Internal.*`)には一切触れていません。

`containers 0.8`の破壊的変更は、
`split`/`splitLookup`/`splitMember`や`fromAscList`系のstrictness変更、
`Data.Set.fold`/`Data.IntSet.fold`のdeprecation、
長期deprecated関数や内部モジュールの公開停止などですが、
いずれも型の再エクスポートには影響しません。

そこで`himari.cabal`の`containers`制約を`>=0.7 && <0.8`から`>=0.7 && <0.9`へ緩和します。
`GHC 9.14.1`(`containers 0.8`同梱)を含む全GHCバージョンで、
`nix flake check`が通ることを確認済みです。

`CHANGELOG.md`の`[Unreleased]`にも依存制約の変更として追記しています。
