### PR TITLE
feat: casing/here/uuidパッケージのre-exportを追加する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - `here` package (>=1.2.14) as a dependency for here documents and string interpolation
 - `Himari.Prelude.Here`: `Data.String.Here` re-exports from the `here` package
   (hiding the overly general `i` and `template` to avoid name conflicts)
+- `uuid` package (>=1.3.16.1) as a dependency for UUID values and their generation
+- `Himari.Prelude.UUID`: `Data.UUID` and `Data.UUID.V4` re-exports
+  from the `uuid` package
+  (hiding the overly general `null`, `toString`, `fromString`, `toText`, and `fromText`
+  to avoid name conflicts)
 
 ## [1.1.4.1] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 - `casing` package (>=0.1.4.1) as a dependency for identifier case conversion
 - `Himari.Prelude.Casing`: `Text.Casing` re-exports from the `casing` package
-  (hiding the overly general `dropPrefix` to avoid name conflicts)
+  (hiding the overly general `dropPrefix`, `toWords`, and `fromWords` to avoid name conflicts)
 - `here` package (>=1.2.14) as a dependency for here documents and string interpolation
 - `Himari.Prelude.Here`: `Data.String.Here` re-exports from the `here` package
   (hiding the overly general `i` and `template` to avoid name conflicts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - `casing` package (>=0.1.4.1) as a dependency for identifier case conversion
 - `Himari.Prelude.Casing`: `Text.Casing` re-exports from the `casing` package
   (hiding the overly general `dropPrefix` to avoid name conflicts)
+- `here` package (>=1.2.14) as a dependency for here documents and string interpolation
+- `Himari.Prelude.Here`: `Data.String.Here` re-exports from the `here` package
+  (hiding the overly general `i` and `template` to avoid name conflicts)
 
 ## [1.1.4.1] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - `uuid` package (>=1.3.16.1) as a dependency for UUID values and their generation
 - `Himari.Prelude.UUID`: `Data.UUID` and `Data.UUID.V4` re-exports
   from the `uuid` package
-  (hiding the overly general `null`, `toString`, `fromString`, `toText`, and `fromText`
+  (hiding the overly general:
+  `null`,
+  `toString`,
+  `fromString`,
+  `toText`,
+  `fromText`,
+  `fromWords`,
+  `toWords`,
   to avoid name conflicts)
 
 ## [1.1.4.1] - 2026-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- `casing` package (>=0.1.4.1) as a dependency for identifier case conversion
+- `Himari.Prelude.Casing`: `Text.Casing` re-exports from the `casing` package
+  (hiding the overly general `dropPrefix` to avoid name conflicts)
+
 ## [1.1.4.1] - 2026-06-13
 
 ### Changed

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -32,6 +32,7 @@ reexports:
   - module Himari.Prelude exports "himari" Himari.Prelude.Here
   - module Himari.Prelude exports "himari" Himari.Prelude.Process
   - module Himari.Prelude exports "himari" Himari.Prelude.TypeLevel
+  - module Himari.Prelude exports "himari" Himari.Prelude.UUID
   - module Himari.Prelude exports "himari" Himari.SafePrelude
 
   # Himari.SafePrelude → 外部モジュール
@@ -162,6 +163,10 @@ reexports:
   # Himari.Prelude.TypeLevel → 外部モジュール
   - module Himari.Prelude.TypeLevel exports "base" Data.Type.Coercion
   - module Himari.Prelude.TypeLevel exports "base" Data.Type.Equality
+
+  # Himari.Prelude.UUID → 外部モジュール
+  - module Himari.Prelude.UUID exports "uuid" Data.UUID
+  - module Himari.Prelude.UUID exports "uuid" Data.UUID.V4
 
 # 利用者向けの汎用的なfixity設定
 # hspecは既にfourmoluによってサポートされているため不要

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -29,6 +29,7 @@ reexports:
   # Himari.Prelude → 内部サブモジュール
   - module Himari.Prelude exports "himari" Himari.Prelude.Aeson
   - module Himari.Prelude exports "himari" Himari.Prelude.Casing
+  - module Himari.Prelude exports "himari" Himari.Prelude.Here
   - module Himari.Prelude exports "himari" Himari.Prelude.Process
   - module Himari.Prelude exports "himari" Himari.Prelude.TypeLevel
   - module Himari.Prelude exports "himari" Himari.SafePrelude
@@ -106,6 +107,9 @@ reexports:
 
   # Himari.Prelude.Casing → 外部モジュール
   - module Himari.Prelude.Casing exports "casing" Text.Casing
+
+  # Himari.Prelude.Here → 外部モジュール
+  - module Himari.Prelude.Here exports "here" Data.String.Here
 
   # Himari.Prelude.Category → 外部モジュール
   - module Himari.Prelude.Category exports "base" Control.Category

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -28,6 +28,7 @@ reexports:
   - module Himari.Prelude exports "unliftio" UnliftIO.IO.File
   # Himari.Prelude → 内部サブモジュール
   - module Himari.Prelude exports "himari" Himari.Prelude.Aeson
+  - module Himari.Prelude exports "himari" Himari.Prelude.Casing
   - module Himari.Prelude exports "himari" Himari.Prelude.Process
   - module Himari.Prelude exports "himari" Himari.Prelude.TypeLevel
   - module Himari.Prelude exports "himari" Himari.SafePrelude
@@ -102,6 +103,9 @@ reexports:
   - module Himari.Prelude.Aeson exports "aeson" Data.Aeson.QQ.Simple
   - module Himari.Prelude.Aeson exports "aeson-pretty" Data.Aeson.Encode.Pretty
   - module Himari.Prelude.Aeson exports "deriving-aeson" Deriving.Aeson
+
+  # Himari.Prelude.Casing → 外部モジュール
+  - module Himari.Prelude.Casing exports "casing" Text.Casing
 
   # Himari.Prelude.Category → 外部モジュール
   - module Himari.Prelude.Category exports "base" Control.Category

--- a/himari.cabal
+++ b/himari.cabal
@@ -93,6 +93,7 @@ common basic
     exceptions >=0.10.9 && <0.11,
     filepath >=1.5.4.0 && <1.6,
     hashable >=1.5.0.0 && <1.6,
+    here >=1.2.14 && <1.3,
     lens >=5.3.5 && <6,
     monad-logger >=0.3.42 && <0.4,
     mtl >=2.3.1 && <2.4,
@@ -126,6 +127,7 @@ library
     Himari.Prelude.Data
     Himari.Prelude.FilePath
     Himari.Prelude.Generics
+    Himari.Prelude.Here
     Himari.Prelude.Monoid
     Himari.Prelude.Process
     Himari.Prelude.Safe

--- a/himari.cabal
+++ b/himari.cabal
@@ -84,6 +84,7 @@ common basic
     aeson-pretty >=0.8.10 && <0.9,
     base >=4.19.2.0 && <4.23,
     bytestring >=0.12.2.0 && <0.13,
+    casing >=0.1.4.1 && <0.2,
     containers >=0.7 && <0.9,
     convertible >=1.1.1.1 && <1.2,
     data-default >=0.8.0.0 && <0.9,
@@ -119,6 +120,7 @@ library
     Himari.Prelude
     Himari.Prelude.Aeson
     Himari.Prelude.Arrow
+    Himari.Prelude.Casing
     Himari.Prelude.Catch
     Himari.Prelude.Category
     Himari.Prelude.Data

--- a/himari.cabal
+++ b/himari.cabal
@@ -106,6 +106,7 @@ common basic
     typed-process >=0.2.13.0 && <0.3,
     unliftio >=0.2.25.1 && <0.3,
     unordered-containers >=0.2.20 && <0.3,
+    uuid >=1.3.16.1 && <1.4,
     vector >=0.13.2.0 && <0.14,
 
 library
@@ -133,6 +134,7 @@ library
     Himari.Prelude.Safe
     Himari.Prelude.Type
     Himari.Prelude.TypeLevel
+    Himari.Prelude.UUID
     Himari.SafePrelude
 
 test-suite himari-test

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -7,6 +7,7 @@ import Control.Monad.Primitive as Export
 import Data.Coerce as Export
 import Debug.Pretty.Simple as Export
 import Himari.Prelude.Aeson as Export
+import Himari.Prelude.Casing as Export
 import Himari.Prelude.Process as Export
 import Himari.Prelude.TypeLevel as Export
 import Himari.SafePrelude as Export

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -11,6 +11,7 @@ import Himari.Prelude.Casing as Export
 import Himari.Prelude.Here as Export
 import Himari.Prelude.Process as Export
 import Himari.Prelude.TypeLevel as Export
+import Himari.Prelude.UUID as Export
 import Himari.SafePrelude as Export
 import UnliftIO as Export
 import UnliftIO.Concurrent as Export

--- a/src/Himari/Prelude.hs
+++ b/src/Himari/Prelude.hs
@@ -8,6 +8,7 @@ import Data.Coerce as Export
 import Debug.Pretty.Simple as Export
 import Himari.Prelude.Aeson as Export
 import Himari.Prelude.Casing as Export
+import Himari.Prelude.Here as Export
 import Himari.Prelude.Process as Export
 import Himari.Prelude.TypeLevel as Export
 import Himari.SafePrelude as Export

--- a/src/Himari/Prelude/Casing.hs
+++ b/src/Himari/Prelude/Casing.hs
@@ -1,0 +1,9 @@
+-- | Re-exports for case conversion of identifiers.
+-- "Text.Casing".
+module Himari.Prelude.Casing
+  ( module Export
+  ) where
+
+-- casing exposes mostly safe pure conversion functions,
+-- but @dropPrefix@ has a name too generic and likely to conflict, so we hide only it.
+import Text.Casing as Export hiding (dropPrefix)

--- a/src/Himari/Prelude/Casing.hs
+++ b/src/Himari/Prelude/Casing.hs
@@ -5,5 +5,6 @@ module Himari.Prelude.Casing
   ) where
 
 -- casing exposes mostly safe pure conversion functions,
--- but @dropPrefix@ has a name too generic and likely to conflict, so we hide only it.
-import Text.Casing as Export hiding (dropPrefix)
+-- but @dropPrefix@, @toWords@, and @fromWords@ have names too generic and likely to conflict,
+-- so we hide them.
+import Text.Casing as Export hiding (dropPrefix, fromWords, toWords)

--- a/src/Himari/Prelude/Here.hs
+++ b/src/Himari/Prelude/Here.hs
@@ -1,0 +1,10 @@
+-- | Re-exports for here documents and string interpolation.
+-- "Data.String.Here".
+module Himari.Prelude.Here
+  ( module Export
+  ) where
+
+-- here exposes compile-time QuasiQuoters that are safe at runtime,
+-- but @i@ and @template@ have names too generic and likely to conflict, so we hide only them.
+-- The hidden quasiquoters are still usable via "Data.String.Here.Interpolated".
+import Data.String.Here as Export hiding (i, template)

--- a/src/Himari/Prelude/UUID.hs
+++ b/src/Himari/Prelude/UUID.hs
@@ -1,0 +1,25 @@
+-- | Re-exports for UUID values and their generation.
+-- "Data.UUID".
+module Himari.Prelude.UUID
+  ( module Export
+  ) where
+
+-- uuid exposes mostly safe total functions returning 'Maybe',
+-- but some names are too generic and likely to conflict, so we hide only them.
+-- @null@, @toString@, @fromString@, @toText@, @fromText@ conflict
+-- with the @base@ and @text@ ecosystem,
+-- and @toWords@, @fromWords@ conflict
+-- with "Text.Casing" from 'Himari.Prelude.Casing'.
+-- The hidden conversions are still usable via a qualified import of "Data.UUID".
+import Data.UUID as Export hiding
+  ( fromString
+  , fromText
+  , fromWords
+  , null
+  , toString
+  , toText
+  , toWords
+  )
+
+-- We will only re-export UUID modules that are practical.
+import Data.UUID.V4 as Export

--- a/src/Himari/Prelude/UUID.hs
+++ b/src/Himari/Prelude/UUID.hs
@@ -6,10 +6,9 @@ module Himari.Prelude.UUID
 
 -- uuid exposes mostly safe total functions returning 'Maybe',
 -- but some names are too generic and likely to conflict, so we hide only them.
--- @null@, @toString@, @fromString@, @toText@, @fromText@ conflict
--- with the @base@ and @text@ ecosystem,
--- and @toWords@, @fromWords@ conflict
--- with "Text.Casing" from 'Himari.Prelude.Casing'.
+-- @null@, @toString@, @fromString@, @toText@, @fromText@ conflict with the @base@ and @text@
+-- ecosystem, and @toWords@, @fromWords@ are likewise too generic
+-- (they are also hidden from 'Himari.Prelude.Casing').
 -- The hidden conversions are still usable via a qualified import of "Data.UUID".
 import Data.UUID as Export hiding
   ( fromString


### PR DESCRIPTION
himariが提供する標準ライブラリの守備範囲を広げるため、
よく使う3つのパッケージを`import Himari`だけで使えるように再エクスポートします。

- `casing`の`Text.Casing`を`Himari.Prelude.Casing`として追加し、
  識別子のケース変換(`camelCase`/`snake_case`/`kebab-case`など)を提供します。
- `here`の`Data.String.Here`を`Himari.Prelude.Here`として追加し、
  ヒアドキュメントと文字列補間を提供します。
- `uuid`の`Data.UUID`と`Data.UUID.V4`を`Himari.Prelude.UUID`として追加し、
  UUID値とその生成を提供します。

いずれのパッケージも実行時に`error`を投げる部分関数は公開していないため、
hlintの警告ルールは追加していません。

一方でこれらは一般的な名前を多く公開しており名前衝突を起こしやすいので、
それぞれ専用サブモジュールへ分離した上で、
衝突しやすい名前だけを`hiding`で除外します。
特に`toWords`と`fromWords`は`casing`と`uuid`の双方に存在し、
ライブラリをまたいで衝突するほど一般的な名前だと判明したため、
両方の由来から除外しています。
隠した名前が必要な利用者は、
各パッケージのモジュールをqualified importして使えます。

依存の追加にあたっては、
それぞれのバージョン規則(PVPなど)に従って上限と下限を設定し、
利用者にも配布される`fourmolu.yaml`の`reexports`チェーンと、
`CHANGELOG.md`の`[Unreleased]`にも反映しています。

`nix flake check`が全GHCバージョンで通ることを確認済みです。