### PR TITLE
build(deps): `uuid`の下限を`1.3.11`まで緩める

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Changed
+
+- Relax the lower bound of the `uuid` dependency from `>=1.3.16.1` to `>=1.3.11`,
+  the first version that provides all of the re-exported and hidden names
+
 ## [1.1.5.0] - 2026-06-14
 
 ### Added

--- a/himari.cabal
+++ b/himari.cabal
@@ -106,7 +106,7 @@ common basic
     typed-process >=0.2.13.0 && <0.3,
     unliftio >=0.2.25.1 && <0.3,
     unordered-containers >=0.2.20 && <0.3,
-    uuid >=1.3.16.1 && <1.4,
+    uuid >=1.3.11 && <1.4,
     vector >=0.13.2.0 && <0.14,
 
 library


### PR DESCRIPTION
`himari.cabal`の`uuid`制約は下限を`>=1.3.16.1`としていましたが、
これは追加時に「確実にビルドできる最新版」として選んだ値で、
機能的に必要な下限よりもかなり厳しすぎました。

himariが`uuid`から使っているのは`Data.UUID`と`Data.UUID.V4`の再エクスポートと、
`Himari.Prelude.UUID`での`hiding`対象の名前だけです。
下限を決めるのは、
`hiding`している名前(存在しない名前を`hiding`すると警告やエラーになる)が、
全て揃っている最古のバージョンです。
各要素の導入バージョンは以下の通りです。

- `null`: `1.1.1`
- `toString`/`fromString`: `1.1.1`以前
- `Data.UUID.V4`(`nextRandom`): `1.2.6`
- `toWords`/`fromWords`: `1.2.2`
- `toText`/`fromText`: `1.3.11`

最後に追加されたのが`toText`/`fromText`の`1.3.11`なので、
ここまで下限を下げても機能的には何も失いません。
そこで`himari.cabal`の制約を`>=1.3.16.1 && <1.4`から`>=1.3.11 && <1.4`へ緩和します。
利用者が他のパッケージと共存させる際の柔軟性が上がります。

`CHANGELOG.md`の`[Unreleased]`にも`Changed`として追記しています。
下限を緩めてもソルバは通常最新版を選ぶため、
全GHCバージョンで`nix flake check`が通ることを確認済みです。
