### PR TITLE
refactor: GHCバージョンを`cabal.project`から読み取る

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,17 @@
       changelog-lint-src,
     }:
     let
-      ghc-version = "ghc9124"; # GHC 9.12.4
+      # `cabal.project`の`with-compiler`で指定したGHCバージョンを尊重し、
+      # 対応するnixpkgsのパッケージセットを選択します。
+      # こうすることでGHCバージョンの管理が`cabal.project`に一元化されます。
+      cabalHaskellGhcVersion =
+        let
+          m = builtins.match ".*with-compiler:[[:space:]]*ghc-([0-9.]+).*" (
+            builtins.readFile ./cabal.project
+          );
+        in
+        if m == null then throw "cabal.projectにwith-compilerが見つかりません" else builtins.head m;
+      ghc-version = "ghc${builtins.replaceStrings [ "." ] [ "" ] cabalHaskellGhcVersion}";
       cabal-version = "3.16.1.0";
       hls-version = "2.13.0.0";
       # cabalビルドに必要なファイルのみを含める。


### PR DESCRIPTION
これまで`flake.nix`の`ghc-version`はnixpkgsのパッケージセット名を、
`"ghc9124"`のようにハードコードしていました。
一方で`cabal.project`の`with-compiler`でも同じGHCバージョンを指定しており、
GHCバージョンを変える際に2箇所を手動で揃える必要がありました。

そこで`cabal.project`を`builtins.readFile`で読み、
`with-compiler: ghc-X.Y.Z`からバージョンを正規表現で抽出して、
`ghcX YZ`形式のnixpkgsパッケージセット名へ変換するようにします。
これによりGHCバージョンの管理が`cabal.project`に一元化され、
両者がずれる事故を防げます。

`with-compiler`が見つからない場合は`throw`で明示的に失敗させ、
意図しないフォールバックが起きないようにしています。
