### PR TITLE
feat: `Data.Containers.ListUtils`を`L`としてqualified importするルールを追加

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -908,6 +908,9 @@
     - as: L
       importStyle: explicitOrQualified
       name: Data.List
+    - as: L
+      importStyle: explicitOrQualified
+      name: Data.Containers.ListUtils
     - as: NE
       importStyle: explicitOrQualified
       name: Data.List.NonEmpty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- hlint rule to import `Data.Containers.ListUtils` qualified as `L`,
+  matching the alias used for `Data.List`
+
 ### Changed
 
 - Relax the lower bound of the `uuid` dependency from `>=1.3.16.1` to `>=1.3.11`,

--- a/hlint/rules/qualified-imports.dhall
+++ b/hlint/rules/qualified-imports.dhall
@@ -49,6 +49,8 @@ let hashSet = Builder.qualifiedAs "Data.HashSet" "HS"
 
 let list = Builder.qualifiedAs "Data.List" "L"
 
+let listUtils = Builder.qualifiedAs "Data.Containers.ListUtils" "L"
+
 let nonEmpty = Builder.qualifiedAs "Data.List.NonEmpty" "NE"
 
 let char = Builder.qualifiedAs "Data.Char" "C"
@@ -87,6 +89,7 @@ let rules
           , hashMapLazy
           , hashSet
           , list
+          , listUtils
           , nonEmpty
           , char
           , aesonKey


### PR DESCRIPTION
`Data.Containers.ListUtils`の`nubOrd`などはリスト系のユーティリティなので、
`Data.List`と同じ`L`エイリアスで揃えると一貫性があり覚えやすいです。
そこで`hlint/rules/qualified-imports.dhall`に`listUtils`定義を追加し、
`.hlint.yaml`を再生成しました。

このルールは利用者にも配布されるため、
`CHANGELOG.md`の`[Unreleased]`にも`Added`として追記しています。
