### PR TITLE
ci: zizmorの`secrets-outside-env`を無効化

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -30,7 +30,6 @@ jobs:
           - ubuntu-24.04-arm # aarch64-linux
           - macos-15 # aarch64-darwin
     runs-on: ${{ matrix.os }}
-    environment: development
     permissions:
       contents: read # Read repository contents
       id-token: write # niks3 OIDC authentication

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,6 @@ jobs:
           - ubuntu-24.04-arm # aarch64-linux
           - macos-15 # aarch64-darwin
     runs-on: ${{ matrix.os }}
-    environment: development
     permissions:
       contents: read # Read repository contents
       id-token: write # niks3 OIDC authentication
@@ -81,7 +80,6 @@ jobs:
   format:
     name: format
     runs-on: ubuntu-24.04
-    environment: development
     permissions:
       contents: read # Read repository contents
       id-token: write # niks3 OIDC authentication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-24.04
-    environment: production
     permissions:
       contents: write # タグ作成のため
       id-token: write # niks3 OIDC認証

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  # `secrets-outside-env`はトークンをEnvironmentに紐付けず参照するのを警告する。
+  # しかしEnvironmentのprotection rules(承認ゲート)は、
+  # private repositoryではGitHub Pro以上が必要。
+  # deploymentの表示も個人ライブラリのpublishでは過剰。
+  # どうせ書き込み権限がないとsecretは読めない。
+  # 承認ゲートが必要なシークレットだけ理解のもとでEnvironmentに入れれば十分。
+  # ルールごと無視します。
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
現状鬱陶しいだけで益がないため。
このリポジトリにじゃんじゃん外部コントリビュータが参加するようになったら、
シークレットの環境経由の入力を復活させるかもしれません。
