### PR TITLE
refactor: `.hlint.yaml`と`fourmolu.yaml`の`data-files`配布をやめる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - Relax the lower bound of the `uuid` dependency from `>=1.3.16.1` to `>=1.3.11`,
   the first version that provides all of the re-exported and hidden names
 
+### Removed
+
+- Stop distributing `.hlint.yaml` and `fourmolu.yaml` as Cabal `data-files`,
+  since downstream usage cannot be verified.
+  `.hlint.yaml` is kept under `extra-source-files` only because the test suite needs it
+
 ## [1.1.5.0] - 2026-06-14
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -55,9 +55,8 @@
             ./himari.cabal
             # license-file
             ./LICENSE
-            # data-files
+            # extra-source-files
             ./.hlint.yaml
-            ./fourmolu.yaml
             # extra-doc-files
             ./CHANGELOG.md
             ./README.md

--- a/himari.cabal
+++ b/himari.cabal
@@ -18,9 +18,12 @@ maintainer: ncaq@ncaq.net
 copyright: ncaq
 category: Control
 build-type: Simple
-data-files:
+-- テスト(`HlintBaseSpec`など)が`hlint`を実行する際に、
+-- プロジェクトルートの`.hlint.yaml`を読み込むため必要。
+-- `data-files`としての利用者向け配布はやめたが、
+-- テスト実行には必要。
+extra-source-files:
   .hlint.yaml
-  fourmolu.yaml
 
 extra-doc-files:
   CHANGELOG.md


### PR DESCRIPTION
`.hlint.yaml`と`fourmolu.yaml`は利用者にリンター・フォーマッタ設定として配布していましたが、
利用者側でそれらが実際に使われているか検証する仕組みがなく、
配布し続ける意義が薄いと判断しました。
ビルドキャッシュが無意味に途切れる問題(#256)を調べる中で、
これらが`cabalFileset`に含まれてderivationのhashを動かしうることも分かったため、
この機会に配布をやめます。

`fourmolu.yaml`はテストやビルドのどこからも参照されていないため完全に削除します。
一方`.hlint.yaml`はテスト(`HlintBaseSpec`など)が`hlint`実行時にプロジェクトルートから読み込むため、
`data-files`ではなく`extra-source-files`へ移して、
利用者向けの配布はやめつつテスト実行に必要なソースとしては残します。

`CHANGELOG.md`の`[Unreleased]`にも`Removed`として追記しています。

ref #256
