### PR TITLE
fix(hlint): convertへの誘導を撤回しdecodeUtf8系のみsafeConvertへ誘導する

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -534,86 +534,14 @@
     - message: "Partial: throws on empty Seq."
       name: Data.Sequence.scanr1
       within: []
-- hint:
-    lhs: Data.Text.pack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.unpack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.pack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.unpack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.toStrict
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.fromStrict
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Encoding.encodeUtf8
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Encoding.decodeUtf8
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Encoding.encodeUtf8
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Encoding.decodeUtf8
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.pack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.unpack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.Lazy.pack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.Lazy.unpack
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.Lazy.toStrict
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.ByteString.Lazy.fromStrict
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Builder.fromText
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Builder.fromLazyText
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Builder.fromString
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
-- hint:
-    lhs: Data.Text.Lazy.Builder.toLazyText
-    note: Use convert from Data.Convertible for uniform type conversion
-    rhs: convert
+- functions:
+    - message: Use safeConvert from Data.Convertible to surface conversion errors as Either ConvertError instead of relying on a partial function
+      name: Data.Text.Encoding.decodeUtf8
+      within: []
+- functions:
+    - message: Use safeConvert from Data.Convertible to surface conversion errors as Either ConvertError instead of relying on a partial function
+      name: Data.Text.Lazy.Encoding.decodeUtf8
+      within: []
 - functions:
     - message: "Don't throw in pure code. Use throwM in MonadThrow context."
       name: throw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Changed
+
+- Stop preferring `convert` over total functions
+  like `pack`, `unpack`, `toStrict`, `fromStrict`, `encodeUtf8`,
+  and lazy/strict `Builder` conversions,
+  because `convert` can be partial depending
+  on the `Convertible` instance and this project avoids partial functions
+- Warn against partial conversion functions like `decodeUtf8`
+  with a message that recommends `safeConvert` from `Data.Convertible`,
+  which returns `Either ConvertError` so the failure can be handled as a value
+  rather than thrown. The rule is a usage restriction rather than a hint,
+  since `safeConvert` is not a drop-in replacement (the return type changes)
+
 ## [1.1.6.0] - 2026-06-16
 
 ### Added

--- a/example/anomaly-monitor/Anomaly.hs
+++ b/example/anomaly-monitor/Anomaly.hs
@@ -5,6 +5,7 @@ module Anomaly
   , formatReport
   ) where
 
+import Data.Text qualified as T
 import Himari
 
 -- | Severity level of detected anomaly.
@@ -39,11 +40,11 @@ formatReport report =
   mconcat
     [ "[ANOMALY DETECTED] "
     , "Severity: "
-    , convert $ show report.severity
+    , T.pack $ show report.severity
     , " | CPU: "
-    , convert $ showFFloat (Just 1) report.cpuUsage "%"
+    , T.pack $ showFFloat (Just 1) report.cpuUsage "%"
     , " (threshold: "
-    , convert $ showFFloat (Just 1) report.threshold "%"
+    , T.pack $ showFFloat (Just 1) report.threshold "%"
     , ") | Time: "
-    , convert $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S UTC" report.timestamp
+    , T.pack $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S UTC" report.timestamp
     ]

--- a/example/anomaly-monitor/Config.hs
+++ b/example/anomaly-monitor/Config.hs
@@ -9,6 +9,7 @@ module Config
   , loadConfig
   ) where
 
+import Data.Text qualified as T
 import Exception
 import Himari
 
@@ -42,8 +43,8 @@ loadConfig maybePath = case maybePath of
     logInfoN "No config file specified, using defaults"
     pure def
   Just path -> do
-    logInfoN $ "Loading config from: " <> convert path
+    logInfoN $ "Loading config from: " <> T.pack path
     contentEither <- liftIO $ eitherDecodeFileStrict path
     case contentEither of
-      Left exception -> throwM . ConfigDecodeException $ convert exception
+      Left exception -> throwM . ConfigDecodeException $ T.pack exception
       Right config' -> pure config'

--- a/example/anomaly-monitor/Cpu.hs
+++ b/example/anomaly-monitor/Cpu.hs
@@ -81,7 +81,7 @@ readCpuStats = do
   contentEither <- tryAny . liftIO $ T.readFile "/proc/stat"
   case contentEither of
     Left exception -> do
-      logWarnN $ "Failed to read /proc/stat: " <> convert (displayException exception)
+      logWarnN $ "Failed to read /proc/stat: " <> T.pack (displayException exception)
       pure Nothing
     Right content -> pure $ parseCpuStats content
 
@@ -91,9 +91,9 @@ showIOCpuThreshold = do
   config' <- view config
   return $
     "Configuration: CPU threshold = "
-      <> convert (showFFloat (Just 1) (config' ^. cpuThreshold) "%")
+      <> T.pack (showFFloat (Just 1) (config' ^. cpuThreshold) "%")
       <> ", interval = "
-      <> convert (show $ config' ^. checkInterval)
+      <> T.pack (show $ config' ^. checkInterval)
       <> "s"
       <> ", max checks = "
-      <> convert (show $ config' ^. maxChecks)
+      <> T.pack (show $ config' ^. maxChecks)

--- a/example/anomaly-monitor/Loop.hs
+++ b/example/anomaly-monitor/Loop.hs
@@ -5,6 +5,7 @@ module Loop
 import Anomaly
 import Config
 import Cpu
+import Data.Text qualified as T
 import Env
 import Himari
 
@@ -37,7 +38,7 @@ monitorLoop prevStats checkCount = do
         formattedReport <- mkFormattedReport usage cpuThreshold' severity'
         -- Log based on severity
         case severity' of
-          Normal -> logDebugN $ "System normal. CPU: " <> convert (showFFloat (Just 1) usage "%")
+          Normal -> logDebugN $ "System normal. CPU: " <> T.pack (showFFloat (Just 1) usage "%")
           Warning -> logWarnN formattedReport
           Critical -> logErrorN formattedReport
           Catastrophic -> logErrorN $ "!!! " <> formattedReport <> " !!!"

--- a/hlint/Builder.dhall
+++ b/hlint/Builder.dhall
@@ -29,13 +29,16 @@ let hint
       \(note : Optional Text) ->
         Types.Rule.Hint { hint = { lhs, rhs, note } }
 
-let useConvert
+let useSafeConvert
     : Text -> Types.Rule
-    = \(lhs : Text) ->
-        hint
-          lhs
-          "convert"
-          (Some "Use convert from Data.Convertible for uniform type conversion")
+    = \(name : Text) ->
+        functions
+          [ restrictFunction
+              name
+              (     "Use safeConvert from Data.Convertible to surface conversion errors"
+                ++  " as Either ConvertError instead of relying on a partial function"
+              )
+          ]
 
 let enableGroup
     : Text -> Types.Rule
@@ -117,7 +120,7 @@ in  { restrictFunction
     , restrictInModule
     , functions
     , hint
-    , useConvert
+    , useSafeConvert
     , enableGroup
     , preferModule
     , modules

--- a/hlint/rules/convertible.dhall
+++ b/hlint/rules/convertible.dhall
@@ -6,31 +6,15 @@ let Types = ../Types.dhall
 
 let Builder = ../Builder.dhall
 
-let convertFunctions =
-      [ "Data.Text.pack"
-      , "Data.Text.unpack"
-      , "Data.Text.Lazy.pack"
-      , "Data.Text.Lazy.unpack"
-      , "Data.Text.Lazy.toStrict"
-      , "Data.Text.Lazy.fromStrict"
-      , "Data.Text.Encoding.encodeUtf8"
-      , "Data.Text.Encoding.decodeUtf8"
-      , "Data.Text.Lazy.Encoding.encodeUtf8"
-      , "Data.Text.Lazy.Encoding.decodeUtf8"
-      , "Data.ByteString.pack"
-      , "Data.ByteString.unpack"
-      , "Data.ByteString.Lazy.pack"
-      , "Data.ByteString.Lazy.unpack"
-      , "Data.ByteString.Lazy.toStrict"
-      , "Data.ByteString.Lazy.fromStrict"
-      , "Data.Text.Lazy.Builder.fromText"
-      , "Data.Text.Lazy.Builder.fromLazyText"
-      , "Data.Text.Lazy.Builder.fromString"
-      , "Data.Text.Lazy.Builder.toLazyText"
-      ]
+let safeConvertFunctions =
+      [ "Data.Text.Encoding.decodeUtf8", "Data.Text.Lazy.Encoding.decodeUtf8" ]
 
 let rules
     : List Types.Rule
-    = Prelude.List.map Text Types.Rule Builder.useConvert convertFunctions
+    = Prelude.List.map
+        Text
+        Types.Rule
+        Builder.useSafeConvert
+        safeConvertFunctions
 
 in  rules


### PR DESCRIPTION
このプロジェクトは部分関数をなるべく避ける方針です。
しかし`convert`は`Convertible`のインスタンス次第で部分関数になりうるため、

- `pack`
- `unpack`
- `toStrict`
- `fromStrict`
- `encodeUtf8`

等や、
`Data.ByteString`系の、

- `pack`
- `unpack`
- `toStrict`
- `fromStrict`

等や、
`Data.Text.Lazy.Builder`の変換関数のような、
全域な関数をわざわざ`convert`へ誘導するのは方針と整合しません。
これらのhintを全て削除します。

一方で`decodeUtf8`は元から不正なUTF-8で例外を投げる部分関数なので、
ここに限っては`convertible`の`safeConvert`の使用を促します。
`safeConvert`は`Either ConvertError`を返すため、
変換失敗を例外ではなく値として扱えるようになり、
部分関数を避ける方針にも沿います。
ただし`safeConvert`は戻り値の型が`Either`に変わり、
`decodeUtf8`をそのまま機械的に置き換えられるわけではないため、
`lhs`/`rhs`形式のhintではなく、
`decodeUtf8`の使用自体を制限してメッセージで`safeConvert`を案内する形にしています。

この方針変更に伴い、
`example/anomaly-monitor`で`String -> Text`の変換に使われていた`convert`は、
全域な`Data.Text.pack`をわざわざ部分関数になりうる`convert`へ流す形になっていたため、
`T.pack`へ置き換えます。

`CHANGELOG.md`の`[Unreleased]`にも`Changed`として追記しています。
