### PR TITLE
ci: strategyに`fail-fast: false`を付与

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -23,6 +23,7 @@ jobs:
   cache-dev-shell:
     name: cache-dev-shell
     strategy:
+      fail-fast: false
       matrix:
         # WindowsはNixが対応していないので対象外です。
         os:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,7 @@ jobs:
   nix-flake-check:
     name: nix-flake-check
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-24.04 # x86_64-linux


### PR DESCRIPTION
キャッシュのダウンロードに時間がかかるのもあるので、
他のランナーが失敗しても、
自分自体が失敗するまで走り続けてほしいため。

一般的な慣習としてもこちらの方が好まれる。
