### PR TITLE
build(deps): cabalのindex-stateを更新

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 with-compiler: ghc-9.12.4
-index-state: 2026-06-12T22:05:25Z
+index-state: 2026-07-25T23:29:42Z
 packages: .
 
 package *


### PR DESCRIPTION
`cabal.project`の`index-state`を`2026-07-25T23:29:42Z`に更新しました。