### PR TITLE
build: devShellから`nil`を削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,9 +151,6 @@
                 typos
                 zizmor
 
-                # nixの関連ツール。
-                nil
-
                 # GitHub関連ツール。
                 gh
 


### PR DESCRIPTION
NixのLSPとして`nil`と`nixd`のどちらを使うかはホスト環境に任せるため、
devShellから`nil`を削除しました。
セットアップは複雑ではなくプロジェクトのバージョンにも依存しないため、
プロジェクト側で実装を固定する必要はありません。

`nil`がnix関連ツールのセクションで唯一の項目だったため、
セクションのコメントも一緒に削除しています。

ref https://github.com/ncaq/nix-templates/pull/291